### PR TITLE
fix(legal): Remove Stripe refs, add GDPR compliance

### DIFF
--- a/src/app/(public)/(policies)/obchodne-podmienky/page.tsx
+++ b/src/app/(public)/(policies)/obchodne-podmienky/page.tsx
@@ -31,8 +31,8 @@ export default function ObchodnePodmienkyPage() {
           kúpnej zmluvy, kedy na jednej strane je spoločnosť KROMKA s.r.o., IČO:
           46 670 068, so sídlom ul. 17. novembra 8288/106, Prešov 080 01,
           zapísaná v Obchodnom registri Okresného súdu Prešov, Oddiel: Sro,
-          Vložka číslo: 26041/P (ďalej len "predávajúci") a na druhej strane je
-          zákazník (ďalej len "kupujúci").
+          Vložka číslo: 26041/P (ďalej len &quot;predávajúci&quot;) a na druhej
+          strane je zákazník (ďalej len &quot;kupujúci&quot;).
         </p>
         <div className="font-normal text-base">
           <p className="font-normal text-base">
@@ -108,8 +108,8 @@ export default function ObchodnePodmienkyPage() {
           <p className="font-normal text-base">3.2. Komentáre a hodnotenia:</p>
           <ul className="ml-6 list-disc space-y-1">
             <li>
-              Používateľ môže pridávať komentáre a označovať obsah ako "Páči sa
-              mi"
+              Používateľ môže pridávať komentáre a označovať obsah ako
+              &quot;Páči sa mi&quot;
             </li>
             <li>
               Komentáre musia byť vecné a nesmú obsahovať urážlivý, nezákonný
@@ -144,47 +144,75 @@ export default function ObchodnePodmienkyPage() {
             kupujúci uhradiť nasledovnými spôsobmi:
           </p>
           <ul className="ml-6 list-disc space-y-1">
-            <li>Platba kartou online prostredníctvom služby Stripe</li>
             <li>Platba v hotovosti pri osobnom odbere</li>
             <li>Platba kartou pri osobnom odbere</li>
           </ul>
         </div>
         <p className="font-normal text-base">
-          4.2. V prípade platby prostredníctvom platobnej brány Stripe postupuje
-          kupujúci podľa pokynov príslušného poskytovateľa elektronických
-          platieb.
+          4.2. Platba kartou je spracovaná prostredníctvom platobného terminálu
+          na predajnom mieste. Predávajúci neuchováva údaje o platobných kartách
+          kupujúceho.
         </p>
         <p className="font-normal text-base">
-          4.3. Predávajúci vystaví kupujúcemu daňový doklad - faktúru. Daňový
+          4.3. Pre B2B zákazníkov (firemných odberateľov) je k dispozícii platba
+          na faktúru so splatnosťou podľa individuálnej dohody.
+        </p>
+        <p className="font-normal text-base">
+          4.4. Predávajúci vystaví kupujúcemu daňový doklad — faktúru. Daňový
           doklad je odoslaný na elektronickú adresu kupujúceho.
         </p>
       </article>
 
-      <article className="space-y-4" id="zaverecne-ustanovenia">
-        <h2 className="font-semibold text-xl">5. Záverečné ustanovenia</h2>
+      <article className="space-y-4" id="objednavka-osobny-odber">
+        <h2 className="font-semibold text-xl">5. Objednávka a osobný odber</h2>
         <p className="font-normal text-base">
-          5.1. Všetky právne vzťahy vznikajúce na základe alebo v súvislosti s
+          5.1. Kupujúci si objednáva tovar prostredníctvom e-shopu
+          predávajúceho. Po odoslaní objednávky obdrží kupujúci potvrdenie na
+          svoju e-mailovú adresu.
+        </p>
+        <p className="font-normal text-base">
+          5.2. Kupujúci si pri objednávke zvolí predajňu a časové okno pre
+          osobný odber. Tovar je potrebné vyzdvihnúť v rámci zvoleného časového
+          okna.
+        </p>
+        <p className="font-normal text-base">
+          5.3. Ak si kupujúci objednaný tovar nevyzdvihne v stanovenom čase,
+          objednávka môže byť zrušená. Predávajúci si vyhradzuje právo účtovať
+          náklady spojené s prípravou nevyzdvihnutej objednávky.
+        </p>
+        <p className="font-normal text-base">
+          5.4. Vzhľadom na to, že predmetom predaja je tovar podliehajúci
+          rýchlej skaze (pekárenské a cukrárenské výrobky), kupujúci nemôže
+          odstúpiť od zmluvy v zmysle §7 ods. 6 písm. d) Zákona č. 102/2014 Z.z.
+          o ochrane spotrebiteľa pri predaji tovaru na diaľku.
+        </p>
+      </article>
+
+      <article className="space-y-4" id="zaverecne-ustanovenia">
+        <h2 className="font-semibold text-xl">6. Záverečné ustanovenia</h2>
+        <p className="font-normal text-base">
+          6.1. Všetky právne vzťahy vznikajúce na základe alebo v súvislosti s
           týmito obchodnými podmienkami sa riadia právnym poriadkom Slovenskej
           republiky.
         </p>
         <p className="font-normal text-base">
-          5.2. V prípade sporu medzi predávajúcim a kupujúcim môže kupujúci
+          6.2. V prípade sporu medzi predávajúcim a kupujúcim môže kupujúci
           využiť možnosť mimosúdneho riešenia sporu. V takom prípade môže
           kupujúci kontaktovať subjekt mimosúdneho riešenia sporov.
         </p>
         <p className="font-normal text-base">
-          5.3. Tieto obchodné podmienky nadobúdajú účinnosť dňom ich
+          6.3. Tieto obchodné podmienky nadobúdajú účinnosť dňom ich
           zverejnenia. Predávajúci si vyhradzuje právo zmeniť tieto obchodné
           podmienky. Zmenu obchodných podmienok predávajúci zverejní na svojich
           internetových stránkach.
         </p>
         <p className="font-normal text-base">
-          5.4. Kupujúci vyjadruje súhlas s týmito obchodnými podmienkami pri
+          6.4. Kupujúci vyjadruje súhlas s týmito obchodnými podmienkami pri
           vytvorení používateľského účtu alebo pri odoslaní objednávky.
         </p>
         <div className="font-normal text-base">
           <p className="font-normal text-base">
-            5.5. Neoddeliteľnou súčasťou týchto obchodných podmienok sú aj:
+            6.5. Neoddeliteľnou súčasťou týchto obchodných podmienok sú aj:
           </p>
           <ul className="ml-6 list-disc space-y-1">
             <li>Zásady ochrany osobných údajov</li>
@@ -192,7 +220,7 @@ export default function ObchodnePodmienkyPage() {
           </ul>
         </div>
         <p className="mt-8 text-muted-foreground text-sm italic">
-          Tieto obchodné podmienky sú platné a účinné od 1.12.2024
+          Tieto obchodné podmienky sú platné a účinné od 17.02.2026
         </p>
       </article>
     </PageWrapper>

--- a/src/app/(public)/(policies)/ochrana-osobnych-udajov/page.tsx
+++ b/src/app/(public)/(policies)/ochrana-osobnych-udajov/page.tsx
@@ -30,8 +30,9 @@ export default function OchranaOsobnychUdajovPage() {
           1.1. Prevádzkovateľom osobných údajov podľa čl. 4 bod 7 nariadenia
           Európskeho parlamentu a Rady (EÚ) 2016/679 o ochrane fyzických osôb
           pri spracúvaní osobných údajov a o voľnom pohybe takýchto údajov
-          (ďalej len "GDPR") je KROMKA s.r.o., IČO: 46 670 068, so sídlom ul.
-          17. novembra 8288/106, Prešov 080 01 (ďalej len "prevádzkovateľ").
+          (ďalej len &quot;GDPR&quot;) je KROMKA s.r.o., IČO: 46 670 068, so
+          sídlom ul. 17. novembra 8288/106, Prešov 080 01 (ďalej len
+          &quot;prevádzkovateľ&quot;).
         </p>
         <div className="font-normal text-base">
           <p className="font-normal text-base">
@@ -78,17 +79,52 @@ export default function OchranaOsobnychUdajovPage() {
             <li>Meno a priezvisko</li>
             <li>E-mailovú adresu</li>
             <li>Telefónne číslo</li>
+            <li>
+              Pri prihlásení cez Google: meno, e-mail a profilový obrázok z
+              Google účtu
+            </li>
           </ul>
         </div>
         <div className="font-normal text-base">
+          <p className="font-normal text-base">2.3. Platobné údaje:</p>
+          <ul className="ml-6 list-disc space-y-1">
+            <li>
+              Platby sú realizované výlučne na predajnom mieste (v hotovosti
+              alebo kartou cez platobný terminál)
+            </li>
+            <li>
+              Prevádzkovateľ neuchováva ani nespracúva údaje o platobných
+              kartách zákazníkov
+            </li>
+          </ul>
+        </div>
+      </article>
+
+      <article className="space-y-4" id="pravny-zaklad">
+        <h2 className="font-semibold text-xl">3. Právny základ spracúvania</h2>
+        <div className="font-normal text-base">
           <p className="font-normal text-base">
-            2.3. Pri platbe cez Stripe spracúvame:
+            3.1. Osobné údaje spracúvame na základe nasledujúcich právnych
+            základov podľa čl. 6 GDPR:
           </p>
           <ul className="ml-6 list-disc space-y-1">
-            <li>Platobné údaje v rozsahu nevyhnutnom pre realizáciu platby</li>
             <li>
-              Platobné údaje nie sú ukladané na našich serveroch, ale sú
-              spracúvané priamo spoločnosťou Stripe
+              <span className="font-semibold">Plnenie zmluvy</span> (čl. 6 ods.
+              1 písm. b) — spracovanie objednávok, správa používateľského účtu,
+              komunikácia so zákazníkom
+            </li>
+            <li>
+              <span className="font-semibold">Súhlas</span> (čl. 6 ods. 1 písm.
+              a) — analytické cookies (PostHog), marketingová komunikácia
+            </li>
+            <li>
+              <span className="font-semibold">Oprávnený záujem</span> (čl. 6
+              ods. 1 písm. f) — zabezpečenie webovej stránky, predchádzanie
+              podvodom, základná analýza návštevnosti
+            </li>
+            <li>
+              <span className="font-semibold">Zákonná povinnosť</span> (čl. 6
+              ods. 1 písm. c) — plnenie daňových a účtovných povinností
             </li>
           </ul>
         </div>
@@ -96,16 +132,16 @@ export default function OchranaOsobnychUdajovPage() {
 
       <article className="space-y-4" id="ucel-spracovania">
         <h2 className="font-semibold text-xl">
-          3. Účel spracovania osobných údajov
+          4. Účel spracovania osobných údajov
         </h2>
         <div className="font-normal text-base">
           <p className="font-normal text-base">
-            3.1. Osobné údaje spracúvame na tieto účely:
+            4.1. Osobné údaje spracúvame na tieto účely:
           </p>
           <ul className="ml-6 list-disc space-y-1">
             <li>Vytvorenie a správa používateľského účtu</li>
             <li>Poskytovanie personalizovaných služieb</li>
-            <li>Spracovanie objednávok a platieb</li>
+            <li>Spracovanie objednávok</li>
             <li>Komunikácia so zákazníkom</li>
             <li>Plnenie zákonných povinností</li>
           </ul>
@@ -113,10 +149,10 @@ export default function OchranaOsobnychUdajovPage() {
       </article>
 
       <article className="space-y-4" id="doba-uchovavania">
-        <h2 className="font-semibold text-xl">4. Doba uchovávania údajov</h2>
+        <h2 className="font-semibold text-xl">5. Doba uchovávania údajov</h2>
         <div className="font-normal text-base">
           <p className="font-normal text-base">
-            4.1. Osobné údaje spracúvame a uchovávame:
+            5.1. Osobné údaje spracúvame a uchovávame:
           </p>
           <ul className="ml-6 list-disc space-y-1">
             <li>Po dobu používania účtu</li>
@@ -125,30 +161,67 @@ export default function OchranaOsobnychUdajovPage() {
           </ul>
         </div>
         <p className="font-normal text-base">
-          4.2. Po uplynutí doby uchovávania osobných údajov prevádzkovateľ
+          5.2. Po uplynutí doby uchovávania osobných údajov prevádzkovateľ
           osobné údaje vymaže.
         </p>
       </article>
 
       <article className="space-y-4" id="prijemcovia">
         <h2 className="font-semibold text-xl">
-          5. Príjemcovia osobných údajov
+          6. Príjemcovia a sprostredkovatelia
         </h2>
         <p className="font-normal text-base">
-          5.1. K osobným údajom majú prístup len oprávnení zamestnanci
+          6.1. K osobným údajom majú prístup len oprávnení zamestnanci
           prevádzkovateľa.
         </p>
+        <div className="font-normal text-base">
+          <p className="font-normal text-base">
+            6.2. Na prevádzku služieb využívame nasledujúcich
+            sprostredkovateľov:
+          </p>
+          <ul className="ml-6 list-disc space-y-1">
+            <li>
+              <span className="font-semibold">Vercel Inc.</span> (USA) — hosting
+              webovej stránky. Prenos údajov do USA je zabezpečený štandardnými
+              zmluvnými doložkami EÚ (SCC).
+            </li>
+            <li>
+              <span className="font-semibold">PostHog Inc.</span> — analytický
+              nástroj. Dáta sú uložené v EÚ (eu.posthog.com). Aktivovaný len s
+              výslovným súhlasom používateľa.
+            </li>
+            <li>
+              <span className="font-semibold">Neon Inc.</span> — databázové
+              služby. Dáta sú uložené v EÚ regióne.
+            </li>
+            <li>
+              <span className="font-semibold">Google LLC</span> (USA) —
+              autentifikácia cez Google OAuth. Prenos údajov do USA je
+              zabezpečený štandardnými zmluvnými doložkami EÚ (SCC).
+            </li>
+          </ul>
+        </div>
+      </article>
+
+      <article className="space-y-4" id="prenos-udajov">
+        <h2 className="font-semibold text-xl">7. Medzinárodný prenos údajov</h2>
         <p className="font-normal text-base">
-          5.2. Na spracovanie platieb využívame službu Stripe, ktorá spracúva
-          platobné údaje v súlade s GDPR.
+          7.1. Niektorí z našich sprostredkovateľov (Vercel, Google) sídlia v
+          USA. Prenos osobných údajov do tretích krajín je zabezpečený
+          prostredníctvom štandardných zmluvných doložiek (SCC) schválených
+          Európskou komisiou v súlade s čl. 46 ods. 2 písm. c) GDPR.
+        </p>
+        <p className="font-normal text-base">
+          7.2. Dáta analytického nástroja PostHog a databázy Neon sú uložené
+          výlučne v EÚ regióne.
         </p>
       </article>
 
       <article className="space-y-4" id="prava-osoby">
-        <h2 className="font-semibold text-xl">6. Práva dotknutej osoby</h2>
+        <h2 className="font-semibold text-xl">8. Práva dotknutej osoby</h2>
         <div className="font-normal text-base">
           <p className="font-normal text-base">
-            6.1. Za podmienok stanovených v GDPR máte:
+            8.1. Za podmienok stanovených v GDPR máte:
           </p>
           <ul className="ml-6 list-disc space-y-1">
             <li>Právo na prístup k svojim osobným údajom</li>
@@ -161,7 +234,7 @@ export default function OchranaOsobnychUdajovPage() {
           </ul>
         </div>
         <p className="font-normal text-base">
-          6.2. Ďalej máte právo podať sťažnosť na Úrade pre ochranu osobných
+          8.2. Ďalej máte právo podať sťažnosť na Úrade pre ochranu osobných
           údajov v prípade, že sa domnievate, že bolo porušené Vaše právo na
           ochranu osobných údajov.
         </p>
@@ -169,33 +242,33 @@ export default function OchranaOsobnychUdajovPage() {
 
       <article className="space-y-4" id="zabezpecenie">
         <h2 className="font-semibold text-xl">
-          7. Zabezpečenie osobných údajov
+          9. Zabezpečenie osobných údajov
         </h2>
         <p className="font-normal text-base">
-          7.1. Prevádzkovateľ vyhlasuje, že prijal všetky primerané technické a
+          9.1. Prevádzkovateľ vyhlasuje, že prijal všetky primerané technické a
           organizačné opatrenia na zabezpečenie osobných údajov.
         </p>
         <p className="font-normal text-base">
-          7.2. Prevádzkovateľ prijal technické opatrenia na zabezpečenie
+          9.2. Prevádzkovateľ prijal technické opatrenia na zabezpečenie
           dátových úložísk a úložísk osobných údajov v písomnej podobe.
         </p>
       </article>
 
       <article className="space-y-4" id="zaverecne-ustanovenia">
-        <h2 className="font-semibold text-xl">8. Záverečné ustanovenia</h2>
+        <h2 className="font-semibold text-xl">10. Záverečné ustanovenia</h2>
         <p className="font-normal text-base">
-          8.1. Odoslaním registračného formulára potvrdzujete, že ste oboznámení
-          s podmienkami ochrany osobných údajov a že ich v celom rozsahu
-          prijímate.
+          10.1. Odoslaním registračného formulára potvrdzujete, že ste
+          oboznámení s podmienkami ochrany osobných údajov a že ich v celom
+          rozsahu prijímate.
         </p>
         <p className="font-normal text-base">
-          8.2. Prevádzkovateľ je oprávnený tieto podmienky zmeniť. Novú verziu
+          10.2. Prevádzkovateľ je oprávnený tieto podmienky zmeniť. Novú verziu
           podmienok ochrany osobných údajov zverejní na svojich internetových
           stránkach.
         </p>
         <p className="mt-8 text-muted-foreground text-sm italic">
           Tieto podmienky ochrany osobných údajov sú platné a účinné od
-          1.12.2024
+          17.02.2026
         </p>
       </article>
     </PageWrapper>

--- a/src/app/(public)/(policies)/pouzivanie-cookies/page.tsx
+++ b/src/app/(public)/(policies)/pouzivanie-cookies/page.tsx
@@ -50,6 +50,29 @@ export default function PouzivanieCookiesPage() {
                 <li>Umožňujú prihlásenie a autentifikáciu používateľa</li>
                 <li>Uchovávajú obsah košíka</li>
               </ul>
+              <div className="mt-2 ml-6">
+                <p className="font-medium text-muted-foreground text-sm">
+                  Konkrétne nevyhnutné cookies:
+                </p>
+                <ul className="ml-4 list-disc space-y-1 text-sm">
+                  <li>
+                    <span className="font-mono">krmk-kosik</span> — obsah
+                    nákupného košíka (30 dní, httpOnly)
+                  </li>
+                  <li>
+                    <span className="font-mono">krmk-kosik-b2b</span> — obsah
+                    B2B košíka (30 dní, httpOnly)
+                  </li>
+                  <li>
+                    <span className="font-mono">kromka-consent</span> —
+                    nastavenia súhlasu s cookies (1 rok)
+                  </li>
+                  <li>
+                    <span className="font-mono">better-auth.session_token</span>{" "}
+                    — autentifikácia prihlásenia
+                  </li>
+                </ul>
+              </div>
             </div>
             <div>
               <p className="font-medium">b) Funkčné cookies:</p>
@@ -230,7 +253,7 @@ export default function PouzivanieCookiesPage() {
         </div>
         <p className="mt-8 text-muted-foreground text-sm italic">
           Tieto zásady používania súborov cookies sú platné a účinné od
-          5.12.2025
+          17.02.2026
         </p>
       </article>
     </PageWrapper>

--- a/src/components/posthog-provider.tsx
+++ b/src/components/posthog-provider.tsx
@@ -5,6 +5,7 @@ import posthog from "posthog-js";
 import { PostHogProvider as PHProvider } from "posthog-js/react";
 import { Suspense, useEffect } from "react";
 import { env } from "@/env";
+import { useConsent } from "@/hooks/use-consent";
 import { consent } from "@/lib/consent";
 import { AuthIdentitySync } from "./auth-identity-sync";
 
@@ -59,16 +60,17 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 function PostHogPageView() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const { analytics } = useConsent();
 
   useEffect(() => {
-    if (pathname) {
+    if (pathname && analytics) {
       const url =
         window.location.origin +
         pathname +
         (searchParams.toString() ? `?${searchParams}` : "");
       posthog.capture("$pageview", { $current_url: url });
     }
-  }, [pathname, searchParams]);
+  }, [pathname, searchParams, analytics]);
 
   return null;
 }


### PR DESCRIPTION
## Summary

- **Remove Stripe references** from all three policy pages (Terms, Privacy, Cookies) — the codebase has no Stripe integration; payments are in-store only
- **Privacy Policy**: Add actual data processors (Vercel, PostHog, Neon, Google), GDPR Art. 6 legal basis section, and international data transfer provisions (SCCs)
- **Terms & Conditions**: Add pickup/order section (perishable goods withdrawal exemption per §7/6/d Zákon 102/2014), B2B invoice payment option
- **Cookie Policy**: Add specific cookie details (`krmk-kosik`, `krmk-kosik-b2b`, `kromka-consent`, `better-auth.session_token`)
- **PostHog pageview**: Gate `$pageview` capture behind explicit analytics consent via `useConsent()` hook

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm build` — passes
- [ ] Manually verify policy page content renders correctly
- [ ] Verify PostHog pageviews are NOT sent before cookie consent
- [ ] Verify PostHog pageviews ARE sent after accepting analytics cookies

🤖 Generated with [Claude Code](https://claude.com/claude-code)