### PR TITLE
feat(seo): add Google Merchant Center product feed

### DIFF
--- a/src/app/api/feed/google/route.ts
+++ b/src/app/api/feed/google/route.ts
@@ -1,0 +1,102 @@
+import type { JSONContent } from "@tiptap/react";
+import { and, eq, notInArray } from "drizzle-orm";
+import { db } from "@/db";
+import { media, products } from "@/db/schema";
+import { jsonContentToText } from "@/lib/editor-utils";
+import { log } from "@/lib/logger";
+import { SITE_NAME } from "@/lib/seo/json-ld";
+import { getSiteUrl } from "@/lib/utils";
+
+const CENTS_PER_EUR = 100;
+const GOOGLE_CATEGORY_ID = 1868;
+
+const FEED_HEADER = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<rss version="2.0" xmlns:g="http://base.google.com/ns/1.0">',
+  "<channel>",
+  `<title>${SITE_NAME}</title>`,
+  `<link>${getSiteUrl()}</link>`,
+  `<description>${SITE_NAME} - Google Shopping feed</description>`,
+];
+const FEED_FOOTER = ["</channel>", "</rss>"];
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export async function GET() {
+  try {
+    const rows = await db
+      .select({
+        id: products.id,
+        name: products.name,
+        slug: products.slug,
+        description: products.description,
+        priceCents: products.priceCents,
+        status: products.status,
+        imageUrl: media.url,
+      })
+      .from(products)
+      .leftJoin(media, eq(products.imageId, media.id))
+      .where(
+        and(
+          eq(products.isActive, true),
+          eq(products.showInB2c, true),
+          notInArray(products.status, ["archived", "draft"])
+        )
+      );
+
+    const items = rows.map((row) => {
+      const description = jsonContentToText(
+        row.description as JSONContent | null
+      );
+      const price = `${(row.priceCents / CENTS_PER_EUR).toFixed(2)} EUR`;
+      const availability = row.status === "sold" ? "out_of_stock" : "in_stock";
+      const link = getSiteUrl(`/product/${row.slug}`);
+
+      return [
+        "<item>",
+        `<g:id>${escapeXml(row.id)}</g:id>`,
+        `<g:title>${escapeXml(row.name)}</g:title>`,
+        `<g:description>${escapeXml(description || row.name)}</g:description>`,
+        `<g:link>${escapeXml(link)}</g:link>`,
+        row.imageUrl
+          ? `<g:image_link>${escapeXml(row.imageUrl)}</g:image_link>`
+          : "",
+        `<g:price>${price}</g:price>`,
+        `<g:availability>${availability}</g:availability>`,
+        `<g:brand>${escapeXml(SITE_NAME)}</g:brand>`,
+        "<g:condition>new</g:condition>",
+        `<g:google_product_category>${GOOGLE_CATEGORY_ID}</g:google_product_category>`,
+        "<g:content_language>sk</g:content_language>",
+        "<g:target_country>SK</g:target_country>",
+        "</item>",
+      ]
+        .filter(Boolean)
+        .join("\n");
+    });
+
+    const xml = [...FEED_HEADER, ...items, ...FEED_FOOTER].join("\n");
+
+    return new Response(xml, {
+      headers: {
+        "Content-Type": "application/xml",
+        "Cache-Control": "s-maxage=3600, stale-while-revalidate",
+      },
+    });
+  } catch (error) {
+    log.db.error({ err: error }, "Google Merchant feed generation failed");
+
+    return new Response([...FEED_HEADER, ...FEED_FOOTER].join("\n"), {
+      headers: {
+        "Content-Type": "application/xml",
+        "Cache-Control": "s-maxage=60, stale-while-revalidate",
+      },
+    });
+  }
+}

--- a/src/lib/editor-utils.ts
+++ b/src/lib/editor-utils.ts
@@ -14,10 +14,23 @@ const SIMPLE_HEADING_LEVELS = [
   HEADING_LEVEL_4,
 ];
 
-/**
- * Convert Tiptap JSONContent to HTML string
- * Useful for SEO, JSON-LD, and meta descriptions
- */
+const EXTENSIONS = [
+  StarterKit.configure({
+    heading: {
+      levels: SIMPLE_HEADING_LEVELS as [
+        typeof HEADING_LEVEL_2,
+        typeof HEADING_LEVEL_3,
+        typeof HEADING_LEVEL_4,
+      ],
+    },
+  }),
+  Link.configure({
+    openOnClick: false,
+    autolink: true,
+    defaultProtocol: "https",
+  }),
+];
+
 export function jsonContentToHtml(
   content: JSONContent | null | undefined
 ): string {
@@ -25,34 +38,13 @@ export function jsonContentToHtml(
     return "";
   }
 
-  const extensions = [
-    StarterKit.configure({
-      heading: {
-        levels: SIMPLE_HEADING_LEVELS as [
-          typeof HEADING_LEVEL_2,
-          typeof HEADING_LEVEL_3,
-          typeof HEADING_LEVEL_4,
-        ],
-      },
-    }),
-    Link.configure({
-      openOnClick: false,
-      autolink: true,
-      defaultProtocol: "https",
-    }),
-  ];
-
   try {
-    return generateHTML(content, extensions);
+    return generateHTML(content, EXTENSIONS);
   } catch {
     return "";
   }
 }
 
-/**
- * Convert Tiptap JSONContent to plain text string
- * Useful for meta descriptions and text-only representations
- */
 export function jsonContentToText(
   content: JSONContent | null | undefined
 ): string {
@@ -60,25 +52,8 @@ export function jsonContentToText(
     return "";
   }
 
-  const extensions = [
-    StarterKit.configure({
-      heading: {
-        levels: SIMPLE_HEADING_LEVELS as [
-          typeof HEADING_LEVEL_2,
-          typeof HEADING_LEVEL_3,
-          typeof HEADING_LEVEL_4,
-        ],
-      },
-    }),
-    Link.configure({
-      openOnClick: false,
-      autolink: true,
-      defaultProtocol: "https",
-    }),
-  ];
-
   try {
-    return generateText(content, extensions);
+    return generateText(content, EXTENSIONS);
   } catch {
     return "";
   }

--- a/src/lib/seo/json-ld.ts
+++ b/src/lib/seo/json-ld.ts
@@ -16,7 +16,7 @@ import type {
 import type { Address, StoreSchedule } from "@/db/types";
 import { getSiteUrl } from "@/lib/utils";
 
-const SITE_NAME = "Pekáreň Kromka";
+export const SITE_NAME = "Pekáreň Kromka";
 const SITE_URL = "https://www.pekarenkromka.sk";
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add public XML feed endpoint at `GET /api/feed/google` for Google Shopping indexing
- Queries active B2C products from DB, outputs Google Shopping RSS 2.0 with all required `g:` namespace fields (id, title, description, link, image, price, availability, brand, condition, category 1868)
- CDN-cached with `s-maxage=3600, stale-while-revalidate`; errors return valid empty feed
- Hoist TipTap extensions to module level in `editor-utils.ts` (avoids per-call recreation)
- Export `SITE_NAME` from `json-ld.ts` for reuse as brand constant

## Test plan

- [ ] `pnpm lint` passes
- [ ] `curl localhost:3000/api/feed/google` returns valid XML with products
- [ ] Verify XML contains correct `xmlns:g` namespace and all required Google Merchant fields
- [ ] Verify `Content-Type: application/xml` and `Cache-Control` headers
- [ ] Confirm empty feed (valid XML, 0 items) returned on DB error

🤖 Generated with [Claude Code](https://claude.com/claude-code)