### PR TITLE
fix(homepage): correct Slovak diacritics in "Naše predajne" title

### DIFF
--- a/src/app/(public)/_components/homepage-stores-content.tsx
+++ b/src/app/(public)/_components/homepage-stores-content.tsx
@@ -79,7 +79,7 @@ export function HomepageStoresContent({
     <section className="space-y-4">
       <div className="flex items-center justify-between gap-4">
         <h2 className="text-balance font-semibold text-xl tracking-tight md:text-2xl">
-          Nase predajne
+          Naše predajne
         </h2>
         <HomepageCtaLink
           className={cn(

--- a/src/app/(public)/_components/homepage-stores-pitch-section.tsx
+++ b/src/app/(public)/_components/homepage-stores-pitch-section.tsx
@@ -219,7 +219,7 @@ export function HomepageStoresPitchSection({
     <section className="space-y-4">
       <div className="flex items-center justify-between gap-4">
         <h2 className="text-balance font-semibold text-xl tracking-tight md:text-2xl">
-          Nase predajne
+          Naše predajne
         </h2>
         <HomepageCtaLink
           className={cn(


### PR DESCRIPTION
## Summary
- Fixes missing Slovak diacritics in the "Naše predajne" section heading on the home page (was rendering as "Nase predajne")
- Updated in both homepage variants: `homepage-stores-content.tsx` and `homepage-stores-pitch-section.tsx`

## Test plan
- [ ] Visit the home page and confirm the stores section heading reads "Naše predajne"
- [ ] Verify both authenticated/unauthenticated states render the correct heading (each component is used in a different homepage variant)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VUcrRVG6bNvQjn1T2MPpu9)_