### PR TITLE
feat: recipe costing + nutrition + ERP profitability arc (A-E)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,20 @@ Detailed documentation for complex features:
 | Checkout | [Overview](features/checkout/README.md), [Changelog](features/checkout/changelog.md) | B2C checkout flow with pickup scheduling |
 | B2B | [Overview](features/b2b/README.md), [Architecture](features/b2b/architecture.md), [API Actions](features/b2b/api-actions.md) | B2B partnership, pricing tiers, and invoice management |
 
+## Specs
+
+Implementation specs for upcoming work. **Read [`specs/_arc-overview.md`](specs/_arc-overview.md) first** for cross-cutting decisions (pricing model, role guards, cache tags, phasing) before diving into any phase spec.
+
+| Spec | Phase | Description |
+|------|-------|-------------|
+| [Arc overview](specs/_arc-overview.md) | — | Pricing model, role guards, cache tags, mobile, rollback, phasing |
+| [Allergens](specs/allergens-phase-a.md) | A | EU 14-allergen tags + PDP chips; pre-A scaffolding (tab structure, `unitCostCents` column, role guards) |
+| [Ingredients catalog](specs/ingredients-phase-b.md) | B | Ingredient CRUD, price history, fuzzy search, duplicate detection, AI nutrition autofill |
+| [Recipes + cost](specs/recipes-phase-c.md) | C | Recipe builder, cost resolver, order snapshot, recipe duplication |
+| [Nutrition + PDP](specs/nutrition-pdp-phase-d.md) | D | Nutrition computation, PDP nutrition table, allergen-source switch, drift report |
+| [ERP profitability](specs/erp-profitability-phase-e.md) | E | Store + product P&L, ingredient trends, CSV export, dashboard widget |
+| [B2B price tiers CRUD](specs/b2b-price-tiers-crud.md) | — | (Independent of the arc.) Full CRUD for B2B price tiers |
+
 ## Adding Documentation
 
 When documenting a feature:

--- a/docs/specs/_arc-overview.md
+++ b/docs/specs/_arc-overview.md
@@ -1,0 +1,366 @@
+# Recipe & Costing Arc — Overview & Cross-Cutting Decisions
+
+This document is the cross-cutting reference for the five-phase arc that delivers allergens, ingredients, recipes, nutrition, and ERP profitability. Each phase spec is self-contained but defers shared decisions (pricing model, role guards, cache tags, mobile expectations, rollback thresholds) to this document so the same choices don't have to be re-discussed five times.
+
+Read this first. Then read the phase you're implementing.
+
+---
+
+## 1. Phase sequencing
+
+```
+[Pre-A scaffolding] → A → B → C → D → E
+```
+
+| Stage | Output | Customer-visible? | Approx duration |
+|---|---|---|---|
+| Pre-A scaffolding | Product page tab refactor, `order_items.unitCostCents` column, role-guard split | No | 1 day |
+| A — Allergens | Manual allergen tags + PDP chips | Yes | 1 sprint |
+| B — Ingredients catalog | Ingredient CRUD, price history, fuzzy search, dup detection, AI nutrition autofill | No | 1-2 sprints |
+| Resolver prototype | Pure-function tests for cost + cycle/depth | No | 1 day |
+| C — Recipes + cost | Builder, resolver, order snapshot, recipe duplication, picker dual-mode | No | 2-3 sprints |
+| D — Nutrition + PDP | Nutrition compute extension, PDP nutrition table, allergen source switch, drift report | Yes | 1 sprint |
+| E — ERP profitability | Store + product P&L, ingredient trends, CSV export, dashboard widget | No (admin) | 1-2 sprints |
+
+**Why pre-A scaffolding exists:** three files get touched 2-3 times each across A/C/D for pure restructure work. Doing the restructure once up front means each phase touches files for substantive reasons.
+
+---
+
+## 2. Pre-A scaffolding (do this once)
+
+A 1-day chunk of pure plumbing, no business logic, no schema risk. Outputs:
+
+### 2a. `order_items.unitCostCents` column
+
+Nullable integer column on `order_items`. Phase A's migration adds it. Phase A doesn't populate it; Phase C is the first phase that writes a value. Lives in Phase A's migration because every order created between A's ship date and C's ship date would otherwise be permanently missing cost data.
+
+```typescript
+// in order_items pgTable definition
+unitCostCents: integer("unit_cost_cents"),   // null until Phase C populates
+```
+
+### 2b. Product detail page tab structure
+
+Wrap the existing product form in shadcn `<Tabs>`. Initial tabs: **Info** | **Recenzie** (existing reviews). URL search param `?tab=info|recenzie`, default `info`.
+
+Future phases extend without re-restructuring:
+- Phase A puts the allergen picker inside Info tab
+- Phase C adds a **Recept** tab
+- Phase D modifies allergen picker behaviour inside Info tab
+- Phase E adds nothing here
+
+### 2c. Role guard split
+
+Add these guards to `src/lib/auth/guards.ts` next to the existing `requireAdmin`, `requireAuth`, `requireStaff`:
+
+```typescript
+// Resource-scoped guards; each maps to a set of roles
+export const requireProductEdit   = () => requireRoles(["admin", "manager"]);
+export const requireRecipeView    = () => requireRoles(["admin", "manager"]);  // baker added in Phase 4
+export const requireRecipeEdit    = () => requireRoles(["admin", "manager"]);
+export const requireCostView      = () => requireRoles(["admin", "manager"]);
+export const requireIngredientEdit = () => requireRoles(["admin", "manager"]);
+export const requireReportsView   = () => requireRoles(["admin", "manager"]);
+```
+
+Each phase uses the resource-scoped guard. When `baker` role lands (ERP Phase 4), only `requireRecipeView` adds it. Zero churn across feature code.
+
+### 2d. New module loggers
+
+`src/lib/logger.ts` — add namespaces that will be used by the arc:
+- `ingredients` (Phase B)
+- `recipes` (Phase C)
+- `nutrition` (Phase D)
+- `reports` (Phase E)
+
+All four added at once in pre-A to avoid one-line edits scattered across phases.
+
+---
+
+## 3. Pricing model (canonical)
+
+**Single source of truth for how money is stored across the entire arc.**
+
+### Storage
+
+| Column | Applies when | Unit |
+|---|---|---|
+| `ingredients.pricePerKgCents` | `baseUnit = 'g'` | integer cents per kilogram |
+| `ingredients.pricePerPieceCents` | `baseUnit = 'piece'` | integer cents per single piece |
+
+Exactly one is non-null, enforced by CHECK:
+
+```sql
+CHECK (
+  (base_unit = 'g'     AND price_per_kg_cents IS NOT NULL AND price_per_piece_cents IS NULL)
+  OR
+  (base_unit = 'piece' AND price_per_piece_cents IS NOT NULL AND price_per_kg_cents IS NULL)
+)
+```
+
+### Why per-kg instead of per-100g or per-gram
+
+Every realistic supplier price is integer-exact at cents/kg granularity:
+
+| Supplier price | Stored as |
+|---|---|
+| €4.00/kg | 400 |
+| €1.20/kg | 120 |
+| €0.85/kg | 85 |
+| €4.99 per 500 g packet | 998 |
+| €2.49/kg | 249 |
+
+Per-gram rounds 0.4 → 0 (useless). Per-100g rounds 0.85 → 0.8 (6% error per ingredient). Per-kg never rounds.
+
+### Admin form: input flexibility
+
+Admin types whatever the invoice says; the form normalizes on save.
+
+```
+Cena                  [4.00]  €  za  [▼ 1 kg          ]
+                                       ├ 1 kg
+                                       ├ 500 g
+                                       ├ 100 g
+                                       ├ 1 kus       (piece-based only)
+                                       └ 12 kusov    (piece-based only)
+
+Uložené ako: 400 c/kg
+```
+
+Live "Uložené ako" hint shows the normalized value so admins catch input mistakes.
+
+### Resolver math
+
+Inside `src/features/recipes/lib/cost-resolver.ts`:
+
+```typescript
+// mass-based item (always quantity in grams)
+itemCostCents = Math.round(quantityGrams * ingredient.pricePerKgCents / 1000);
+
+// piece-based item (always quantity in pieces)
+itemCostCents = quantityPieces * ingredient.pricePerPieceCents;
+```
+
+One division by 1000 at compute time. No precision loss.
+
+### Display helper
+
+`src/features/ingredients/lib/format.ts`:
+
+```typescript
+// Always shows both representations: "4,00 €/kg (0,40 €/100g)"
+export function formatPricePerUnit(ing: IngredientLite): string;
+```
+
+Customers think in per-100g (matching nutrition labels), staff think in per-kg (matching invoices). Display both, store one.
+
+### Price history mirrors the same shape
+
+`ingredient_price_history` carries the same two columns. Every price change appends a row. Phase E reports walk the history without any conversion logic.
+
+---
+
+## 4. Role matrix
+
+What each role sees / can do across the arc:
+
+| Capability | admin | manager | baker (Phase 4) | user (customer) |
+|---|---|---|---|---|
+| View products | ✅ | ✅ | ✅ | public PDP |
+| Edit products | ✅ | ✅ | ❌ | ❌ |
+| View ingredients catalog | ✅ | ✅ | ❌ | ❌ |
+| Edit ingredients | ✅ | ✅ | ❌ | ❌ |
+| View recipes | ✅ | ✅ | ✅ | ❌ |
+| Edit recipes | ✅ | ✅ | ❌ | ❌ |
+| View cost (per recipe, per order) | ✅ | ✅ | ❌ | ❌ |
+| View nutrition on PDP | ✅ | ✅ | ✅ | ✅ |
+| View profitability reports | ✅ | ✅ | ❌ | ❌ |
+
+Bakers see recipes (they execute them) but never cost numbers. Customers see PDP allergens + nutrition. Everyone else is gated.
+
+**Implementation:** use the resource-scoped guards from [§2c](#2c-role-guard-split). Per-store row-level access (a manager assigned to store A sees only store A's reports) lives behind an additional check inside `requireReportsView` once Phase 4 introduces store-staff assignments.
+
+---
+
+## 5. Cache tag matrix
+
+Central reference for which tags get invalidated by which mutations. **Update this file whenever a new tag or mutation is added.**
+
+### Tags by scope
+
+| Tag | Set by | TTL |
+|---|---|---|
+| `allergens` | `getAllergens` | `cacheLife("max")` |
+| `products` | All product queries | `cacheLife("hours")` |
+| `product-${slug}` | PDP query (Phase D) | `cacheLife("hours")` |
+| `ingredients` | All ingredient queries | `cacheLife("hours")` |
+| `ingredient-${id}` | `getIngredientById` | `cacheLife("hours")` |
+| `ingredient-${id}-prices` | `getIngredientPriceHistory` | `cacheLife("hours")` |
+| `recipes` | All recipe queries + `getResolverContext` | `cacheLife("hours")` |
+| `recipe-${id}` | `getRecipeById` | `cacheLife("hours")` |
+| `reports` | All Phase E queries | `cacheLife("hours")` |
+| `reports-stores`, `reports-products`, `reports-summary`, `reports-distribution`, `reports-ingredients-${id}`, `reports-ingredient-impact-${id}` | Phase E sub-queries | `cacheLife("hours")` |
+
+### Invalidations by action
+
+| Mutation | Tags invalidated |
+|---|---|
+| `updateProductAction` (Phase A+) | `products`, `reports` |
+| `createIngredientAction` (Phase B) | `ingredients`, `recipes`, `reports` |
+| `updateIngredientAction` (no price change) | `ingredients`, `ingredient-${id}` |
+| `updateIngredientAction` (price changed) | `ingredients`, `ingredient-${id}`, `ingredient-${id}-prices`, `recipes`, `reports` |
+| `deleteIngredientAction` | `ingredients`, `ingredient-${id}` |
+| `createRecipeAction` (Phase C) | `recipes` |
+| `updateRecipeHeaderAction` | `recipes`, `recipe-${id}`, `products` |
+| `addRecipeItemAction` / `updateRecipeItemAction` / `removeRecipeItemAction` / `reorderRecipeItemsAction` | `recipes`, `recipe-${recipeId}`, `products` (cost preview on PDP), `reports` |
+| `linkProductRecipeAction` | `products`, `product-${slug}`, `recipes` |
+| `publishRecipeAction` | `recipes`, `recipe-${id}`, `reports` |
+| `updateProductAction` with `nutritionOverride` (Phase D) | `products`, `product-${slug}` |
+| `aiAutofillNutritionAction` confirm (Phase B+) | `ingredients`, `ingredient-${id}` |
+| Order creation / status change (Phase C+) | `orders`, `reports` |
+
+**Rule of thumb:** any mutation that changes data feeding into a report invalidates `reports`. Any mutation that changes recipe-derived data invalidates `products` so PDP reflects it.
+
+---
+
+## 6. Mobile expectations matrix
+
+| Phase | Surface | Mobile expectation |
+|---|---|---|
+| A | PDP allergen chips | Full support (already mobile-friendly) |
+| A | Admin product form | Existing form behaviour, no special mobile work |
+| B | Admin ingredients list & form | Functional on mobile; price input dropdown collapses cleanly |
+| C | Recipe builder | **Desktop-only.** Mobile shows read-only view with "Úpravy receptu sú možné len na počítači" banner |
+| C | Recipe list | Functional on mobile |
+| D | PDP nutrition table | Full support; EU-format table works on narrow screens |
+| D | Drift report | Desktop-first; mobile usable but cramped |
+| E | Reports | Desktop-first; charts degrade to scrollable; KPI cards stack vertically |
+
+The only hard "desktop-only" decision is the Phase C recipe builder. Everything else degrades.
+
+---
+
+## 7. Rollback / one-way thresholds
+
+When each phase becomes effectively one-way (rolling back loses real data or user expectations):
+
+| Phase | Becomes one-way at |
+|---|---|
+| Pre-A scaffolding | Immediately reversible (drop column, undo tab wrap) |
+| A — Allergens | After ~1 week of admin tagging — losing manual allergen data would mean re-entering |
+| B — Ingredients | After admins enter real prices + nutrition — losing this is days of work |
+| C — Recipes + cost | The moment real orders start having `unitCostCents` populated. Past that, rollback loses real data. |
+| D — Nutrition + PDP | After customers start seeing nutrition labels on PDP — backward step is a customer-visible regression |
+| E — Reports | After admins start relying on the reports to make decisions — soft expectation lock-in |
+
+Each spec should refer back here rather than re-discussing rollback.
+
+---
+
+## 8. Pre-build prototypes
+
+Three areas where 1 day of prototyping pays for itself before the actual spec build starts:
+
+| Prototype | Goal | Outcome |
+|---|---|---|
+| Resolver pure function | Confidence in cycle/depth/missing-data behaviour, reusable test fixture | TypeScript file with tests covering all error paths, before the rest of Phase C touches it |
+| `useOptimistic` + dnd-kit + autosave (Phase C items table) | Validate the spreadsheet feel is achievable; uncover ordering bugs before they spread | Tiny throwaway page with 3 rows, drag reorder, debounced autosave |
+| `<IngredientForm variant="page" \| "sheet">` (Phase B → Phase C bridge) | Lock the dual-mode contract so Phase C can be built in parallel with Phase B | Storybook-ish or `/admin/ingredients/_demo` page exercising both modes |
+
+---
+
+## 9. Fuzzy search & duplicate detection
+
+Used by Phase B ingredient picker and admin tools.
+
+### Postgres extensions (one-time)
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS unaccent;
+```
+
+Added in Phase B's migration since that's where ingredient name search becomes a load-bearing UX.
+
+### Indexed lookup
+
+```sql
+CREATE INDEX idx_ingredients_name_trgm
+  ON ingredients USING gin (lower(unaccent(name)) gin_trgm_ops);
+```
+
+Enables:
+- Diacritic-free matching: "muka" → "Hladká múka T650"
+- Substring matching: "T550" → "Hladká múka T550"
+- Trigram similarity for duplicate detection at create time
+
+### Duplicate detection in ingredient form
+
+On the create form, after the admin types a name, query similar existing ingredients and surface them as suggestions:
+
+```sql
+SELECT id, name
+FROM ingredients
+WHERE similarity(lower(unaccent(name)), lower(unaccent($1))) > 0.6
+ORDER BY similarity(...) DESC
+LIMIT 5;
+```
+
+UI shows "Možno máte na mysli: Hladká múka T650, Polohrubá múka — klik pre vybranie". Click selects the existing ingredient and closes the create dialog.
+
+### Periodic cleanup tool
+
+`/admin/ingredients/duplicates` — admin page listing pairs above the similarity threshold for review. Read-only diagnostic; no automated merge. Useful for catching diacritic typos and slightly different supplier names for the same thing.
+
+### Why not pgvector
+
+Vector embeddings would handle semantic matches like "biela múka" → "Hladká múka T550" (no trigram overlap, same concept). For our bakery scale and well-known vocabulary, pg_trgm + admin discipline is enough. Vectors stay out of scope for the catalog. **If we ever do vectors, it's for recipe similarity, not ingredient search** — a Phase C+ feature, not a Phase B refactor.
+
+---
+
+## 10. Cross-cutting non-goals
+
+Things that are deliberately out of scope across the entire arc, even though they keep coming up:
+
+- **"May contain traces" / cross-contamination warnings.** Removed in the spike. No room.
+- **Multi-currency.** EUR only.
+- **Multi-language ingredient or recipe names.** Slovak only. Allergens have `nameSk` + `nameEn` (one-time seed cost). Everything else is single-Slovak.
+- **Manual override of computed allergens.** No override layer. Allergens come from the recipe ingredients (Phase D); products without a recipe use the manual `allergenCodes` column (Phase A) as fallback.
+- **Recipe versioning / history.** Cost snapshot on `order_items.unitCostCents` covers historical correctness; full recipe history is too much engineering for too little business value.
+- **`ml` as a base unit.** Two units only: `g` and `piece`. Liquids stored in grams.
+- **Public-facing ingredient list ("Z čoho je vyrobené") on PDP.** Future consideration; not in this arc.
+- **B2B-format printable nutrition labels.** Future; the data model supports it.
+- **Inventory tracking** (stock, expiry, reorder). ERP Phase 4 store-manager work, not part of this arc.
+- **Bulk CSV import** for ingredients or recipes. Out of scope.
+- **Real-time / streaming reports.** Cached with `cacheLife("hours")`. Good enough.
+
+---
+
+## 11. Testing strategy
+
+Each spec lists its specific acceptance criteria. The arc-wide testing expectations:
+
+| Test target | Phase | Why |
+|---|---|---|
+| Cost resolver (`src/features/recipes/lib/cost-resolver.ts`) | C | Pure function, recursive, easy to make subtly wrong; the highest-value test surface in the arc |
+| Nutrition extension to the resolver | D | Same reasoning; adds new math paths to the same function |
+| Cycle / depth / missing-ingredient error paths | C | Silent failures here propagate to wrong costs in production |
+| Order-snapshot fallback (cost resolver throws → NULL persisted, no checkout failure) | C | Critical: cost tracking must never break checkout |
+| Phase E SQL aggregations on a fixture order set | E | Easy to get a FILTER aggregate subtly wrong, hard to spot in a chart |
+| `<IngredientForm>` dual-mode contract | B | Phase C depends on it before Phase C exists; lock the API early |
+
+Tests are written with the existing test runner (Vitest or whatever the project uses). The resolver is a pure function with no DB, so unit tests are cheap.
+
+---
+
+## 12. Open questions kept here so phase specs don't drift
+
+The following are decided once here and referenced from each phase:
+
+1. **Energy on labels: `kJ / kcal`** (both, kJ first) — EU 1169/2011 mandate.
+2. **Salt vs sodium on PDP: salt only.** Schema.org JSON-LD gets sodium via `salt × 0.4` conversion at render time.
+3. **PDP decimals:** kcal → whole number, grams → 1 decimal, kJ → whole number, Slovak decimal comma.
+4. **Order statuses counted as a sale** in Phase E: `["new", "in_progress", "ready_for_pickup", "completed"]`. Excludes `cancelled` and `refunded`.
+5. **Per-store row-level filtering** in Phase E reports: filter shape (`storeIds?: string[]`) is in the query signatures from day one; actual enforcement waits for Phase 4 store-staff assignments.
+6. **Recipe duplication is MVP in Phase C** (not a stretch). The 5-recipes-in-and-you're-reusing pattern is the dominant workflow.
+7. **Ingredient picker has two modes:** "Ingrediencie" + "Z iného receptu" — pulling all items from another recipe is the fastest path to building recipe N when recipe N-1 is similar.

--- a/docs/specs/allergens-phase-a.md
+++ b/docs/specs/allergens-phase-a.md
@@ -1,0 +1,435 @@
+# Allergens (Phase A) — Implementation Spec
+
+> **Read first:** [`_arc-overview.md`](./_arc-overview.md) for cross-cutting decisions (role guards, cache tags, pricing model, mobile, rollback).
+
+## Overview
+
+Add EU 14-allergen support to products. Admin tags each product with the allergens it contains via a chip picker; PDP renders the allergens as labelled chips with Slovak names. No ingredients or recipes yet — Phase A is a standalone, customer-facing slice that delivers EU 1169/2011 compliance and answers the most-asked customer question.
+
+Phase A is **manual tagging**. In Phase D, allergens for products **with a recipe** become derived from the recipe's ingredients. The manual `allergenCodes` column stays in place as the **fallback for products without a recipe** (resold packaged items, simple drinks, etc.). The picker UI becomes conditionally read-only in Phase D when a recipe is linked. See [Migration path to Phase D](#migration-path-to-phase-d).
+
+## Phase A also ships the pre-A scaffolding
+
+Per [`_arc-overview.md` §2](./_arc-overview.md#2-pre-a-scaffolding-do-this-once), the following items ship as part of Phase A's PR to avoid touching the same files 2-3 times across phases:
+
+- **`order_items.unitCostCents` column** (nullable integer) — added to the migration alongside the allergens table. Not populated until Phase C; the column existing now means orders created between A and C aren't permanently cost-blind.
+- **Product detail tab structure** — wrap the existing single-column form in shadcn `<Tabs>` with **Info** | **Recenzie**. URL `?tab=info|recenzie`. Future phases extend (Phase C adds "Recept" tab).
+- **Role-guard split** — add `requireProductEdit`, `requireRecipeView`, `requireRecipeEdit`, `requireCostView`, `requireIngredientEdit`, `requireReportsView` to `src/lib/auth/guards.ts`. Phase A uses `requireProductEdit` for the new action.
+- **Module loggers** — add `ingredients`, `recipes`, `nutrition`, `reports` namespaces to `src/lib/logger.ts` (used by future phases; declared here once).
+
+## Goals
+
+- Admin can tag any product with zero or more EU 14 allergens.
+- PDP renders the allergens as readable Slovak chips with icons (e.g. "Lepok", "Vajcia", "Mlieko").
+- Reference data (the 14 allergens) is seeded once and cached aggressively — it never changes.
+- Zero coupling to ingredients/recipes — Phases B-D can be built independently.
+
+## Non-goals
+
+- "May contain traces" / cross-contamination warnings. **Explicitly excluded.**
+- Allergen-based filtering on the e-shop listing page. (Possible Phase D add-on.)
+- Any override layer (manual additions or exclusions on top of derived data). Phase D switches the data source for products *with* a recipe; the manual column remains for products *without* a recipe.
+- B2B-format printable EU labels.
+
+---
+
+## Current state
+
+### Schema reference points
+- [products](../../src/db/schema.ts) (line 801) — existing table. Will gain one column.
+- No allergen-related tables, columns, or features exist yet.
+
+### Existing product queries
+- `src/features/products/api/queries.ts`
+  - `getProductBySlug(slug)` — public PDP query, cached with tag `products`
+  - `getAdminProductById(id)` — admin edit form query
+  - Both will need to return `allergenCodes`.
+
+### Existing PDP
+- `src/app/(public)/(pages)/product/[slug]/page.tsx` — server component, renders price, stock, description. We insert the allergen section between the description and `AddWithQuantityButton` (around line 279).
+
+### Existing admin product form
+- `src/app/(admin)/admin/products/[id]/_components/product-form.tsx` — `"use client"`, RHF + Zod, calls `updateProductAction`. Picker becomes a new field in this form.
+
+---
+
+## What to build
+
+### 1. Schema changes
+
+**File:** `src/db/schema.ts` — **REQUIRES HUMAN APPROVAL** before edit.
+
+#### New table: `allergens`
+
+Reference table. `code` is the primary key (text), no prefixed CUID — codes are stable EU identifiers. 14 rows, seeded once.
+
+```typescript
+export const allergens = pgTable("allergens", {
+  code: text("code").primaryKey(),       // 'gluten', 'eggs', 'milk', ...
+  nameSk: text("name_sk").notNull(),     // 'Lepok', 'Vajcia', 'Mlieko', ...
+  nameEn: text("name_en").notNull(),     // 'Gluten', 'Eggs', 'Milk', ...
+  sortOrder: integer("sort_order").notNull().default(0),
+});
+```
+
+No relations needed in Phase A — `allergenCodes` on products is a `text[]`, looked up against this table at the application layer.
+
+#### New column on `products`
+
+```typescript
+allergenCodes: text("allergen_codes")
+  .array()
+  .notNull()
+  .default(sql`ARRAY[]::text[]`),
+```
+
+App-level validation (Zod) enforces that every code exists in the seeded `allergens` table. No FK constraint on array elements (PG limitation).
+
+#### New column on `order_items` (pre-A scaffolding)
+
+```typescript
+unitCostCents: integer("unit_cost_cents"),   // nullable; populated by Phase C
+```
+
+Phase A doesn't write or read this column. It exists so orders created between Phase A and Phase C aren't permanently cost-blind once Phase C ships.
+
+#### Migration
+
+1. `pnpm db:generate` — produces the schema migration (allergens table, `products.allergenCodes`, `order_items.unitCostCents`).
+2. **Manually edit** the generated SQL file to append the seed `INSERT` for the 14 allergens (see [seed data](#seed-data) below).
+3. `pnpm db:migrate`.
+
+The seed must live in the migration, not in app code, because the `allergens` table is referenced as a stable enum. A startup-time seeder would race with app code that assumes the rows exist.
+
+### Seed data
+
+The 14 mandatory allergens from EU Regulation 1169/2011 Annex II, with Slovak names:
+
+| code | nameSk | nameEn | sortOrder |
+|---|---|---|---|
+| `gluten` | Lepok | Gluten | 10 |
+| `crustaceans` | Kôrovce | Crustaceans | 20 |
+| `eggs` | Vajcia | Eggs | 30 |
+| `fish` | Ryby | Fish | 40 |
+| `peanuts` | Arašidy | Peanuts | 50 |
+| `soybeans` | Sójové bôby | Soybeans | 60 |
+| `milk` | Mlieko | Milk | 70 |
+| `tree_nuts` | Orechy | Tree nuts | 80 |
+| `celery` | Zeler | Celery | 90 |
+| `mustard` | Horčica | Mustard | 100 |
+| `sesame` | Sezam | Sesame | 110 |
+| `sulphites` | Oxid siričitý a siričitany | Sulphites | 120 |
+| `lupin` | Vlčí bôb | Lupin | 130 |
+| `molluscs` | Mäkkýše | Molluscs | 140 |
+
+`sortOrder` follows the EU's official ordering and is used as the canonical render order on PDP and in the picker.
+
+### 2. Feature module: `src/features/allergens/`
+
+New feature folder. Standard layout:
+
+```
+src/features/allergens/
+├── api/
+│   ├── queries.ts
+│   └── actions.ts
+├── components/
+│   ├── allergen-picker.tsx     # admin
+│   └── allergen-list.tsx        # public PDP
+├── lib/
+│   └── icons.ts                 # code → lucide icon
+└── schema.ts
+```
+
+#### `schema.ts`
+
+```typescript
+import { z } from "zod";
+
+export const ALLERGEN_CODES = [
+  "gluten", "crustaceans", "eggs", "fish", "peanuts", "soybeans",
+  "milk", "tree_nuts", "celery", "mustard", "sesame", "sulphites",
+  "lupin", "molluscs",
+] as const;
+
+export const allergenCodeSchema = z.enum(ALLERGEN_CODES);
+export type AllergenCode = z.infer<typeof allergenCodeSchema>;
+
+export const updateProductAllergensSchema = z.object({
+  productId: z.string().min(1),
+  codes: z.array(allergenCodeSchema),
+});
+
+export type UpdateProductAllergensSchema = z.infer<typeof updateProductAllergensSchema>;
+```
+
+Hardcoding the 14 codes in TS gives us:
+- Compile-time `AllergenCode` type for the picker, list, and icons map.
+- Zod validation without round-tripping the DB.
+- Single source of truth that matches the migration seed.
+
+The DB row count is the runtime counterpart. If the two ever drift, a CI check (`SELECT count(*) FROM allergens` vs. `ALLERGEN_CODES.length`) flags it.
+
+#### `api/queries.ts`
+
+```typescript
+"use cache";
+import { cacheLife, cacheTag } from "next/cache";
+import { db } from "@/db";
+import { allergens } from "@/db/schema";
+
+export async function getAllergens() {
+  cacheLife("max");          // never changes after seed
+  cacheTag("allergens");
+  return db.query.allergens.findMany({
+    orderBy: (a, { asc }) => asc(a.sortOrder),
+  });
+}
+
+export type Allergen = Awaited<ReturnType<typeof getAllergens>>[number];
+```
+
+Cache life `"max"` because the seed never changes. If we ever localize beyond Slovak/English, we'd invalidate manually.
+
+#### `api/actions.ts`
+
+```typescript
+"use server";
+import { revalidateTag } from "next/cache";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { products } from "@/db/schema";
+import { requireAdmin } from "@/lib/auth/guards";
+import { log } from "@/lib/logger";
+import {
+  updateProductAllergensSchema,
+  type UpdateProductAllergensSchema,
+} from "../schema";
+
+export async function updateProductAllergensAction(
+  input: UpdateProductAllergensSchema
+) {
+  await requireAdmin();
+  const parsed = updateProductAllergensSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: "Neplatné údaje" } as const;
+  }
+
+  try {
+    // De-dupe + sort by ALLERGEN_CODES order for canonical storage
+    const codes = [...new Set(parsed.data.codes)];
+    await db
+      .update(products)
+      .set({ allergenCodes: codes })
+      .where(eq(products.id, parsed.data.productId));
+
+    revalidateTag("products");
+    return { success: true } as const;
+  } catch (err) {
+    log.products.error(
+      { err, productId: parsed.data.productId },
+      "Update product allergens failed"
+    );
+    return { success: false, error: "Uloženie zlyhalo" } as const;
+  }
+}
+```
+
+**Note:** Cache invalidation tag is `products` (existing). We do not add a new per-product tag — Phase A keeps it simple. If perf shows whole-catalog invalidation is too aggressive, narrow later.
+
+#### `lib/icons.ts`
+
+Static mapping. Lucide icons are not perfect for food allergens but cover most cases; remaining use a generic `<Circle />` placeholder. The icon set is part of the Slovak-bakery brand call later — for Phase A, ship lucide and iterate.
+
+```typescript
+import {
+  Wheat, Shell, Egg, Fish, Nut, Sprout, Milk, TreePine,
+  Leaf, Flame, Dot, FlaskConical, Bean, Shell as Mollusc,
+  type LucideIcon,
+} from "lucide-react";
+import type { AllergenCode } from "../schema";
+
+export const ALLERGEN_ICONS: Record<AllergenCode, LucideIcon> = {
+  gluten: Wheat,
+  crustaceans: Shell,
+  eggs: Egg,
+  fish: Fish,
+  peanuts: Nut,
+  soybeans: Sprout,
+  milk: Milk,
+  tree_nuts: TreePine,
+  celery: Leaf,
+  mustard: Flame,
+  sesame: Dot,
+  sulphites: FlaskConical,
+  lupin: Bean,
+  molluscs: Mollusc,
+};
+```
+
+#### `components/allergen-picker.tsx` (admin)
+
+`"use client"` chip-toggle picker. Renders one chip per allergen from `getAllergens()` (passed in as a prop from the server form container). Toggling a chip updates an internal state; on submit, the parent form calls `updateProductAllergensAction`.
+
+API:
+```typescript
+type Props = {
+  allergens: Allergen[];           // from getAllergens()
+  value: AllergenCode[];           // currently selected codes
+  onChange: (codes: AllergenCode[]) => void;
+};
+```
+
+Render:
+- Grid of chips (`<Toggle>` from shadcn or custom button with `data-state`)
+- Each chip: lucide icon + `nameSk`
+- Selected chip: filled variant; unselected: outline
+- Sorted by `sortOrder` (already done by query)
+
+This is a pure controlled component — does not call the action directly. Keeps it composable inside the existing RHF product form.
+
+#### `components/allergen-list.tsx` (public PDP)
+
+Server component. Takes the product's `allergenCodes` and the full `allergens` array; renders a horizontal list of chips with icon + Slovak name. Returns `null` if list is empty (no "obsahuje: žiadne alergény" placeholder — silence is the right UX).
+
+```typescript
+type Props = {
+  codes: AllergenCode[];
+  allergens: Allergen[];
+};
+```
+
+Markup is a section with heading "Alergény" and a `flex flex-wrap gap-2` row of `<Badge variant="secondary">` items, each with `<Icon className="size-4" />` + name.
+
+### 3. Update existing product queries
+
+**File:** `src/features/products/api/queries.ts`
+
+Both `getProductBySlug` and `getAdminProductById` already select `*` from products via Drizzle's `findFirst`. Adding `allergenCodes` to the schema means it flows through automatically. Verify by inspecting return types after the schema migration; no code change should be needed beyond TypeScript catching new field availability.
+
+If either query uses a column-list projection, append `allergenCodes` explicitly.
+
+### 4. Wire admin form
+
+**File:** `src/app/(admin)/admin/products/[id]/_components/product-form.tsx`
+
+This file gets two changes in one PR: the tab restructure (pre-A scaffolding) **and** the allergen picker.
+
+**Tab restructure first.** Wrap the existing form content in shadcn `<Tabs>`:
+- `?tab=info` (default) — contains everything currently in the form, including the new allergen picker
+- `?tab=recenzie` — existing reviews section (move from wherever it currently lives)
+
+Tab state lives in URL search params; reads are server-side. This is plumbing only — no behaviour changes beyond the visual tab strip.
+
+**Then add the picker** as a new RHF-controlled field inside the Info tab:
+
+1. Extend the form's Zod schema to include `allergenCodes: z.array(allergenCodeSchema)`.
+2. Pass `allergens` (from a server-side `getAllergens()` call in the parent page) into the form as a prop.
+3. Render `<AllergenPicker>` inside the existing form layout — likely a new section between "Description" and "Pricing".
+
+> **Note for Phase D:** the picker becomes conditionally read-only when a recipe is linked to the product. In Phase A, it's always editable. The Phase D edit is a single conditional render, no structural change.
+4. The existing submit handler (`updateProductAction`) needs to accept `allergenCodes`. Two options:
+   - **Option A (preferred):** Add `allergenCodes` to `updateProductSchema` in `src/features/products/schema.ts` and let the existing `updateProductAction` write it. One round-trip.
+   - **Option B:** Call `updateProductAllergensAction` separately after `updateProductAction`. Two round-trips, awkward error handling. Avoid.
+
+Going with **Option A** — `updateProductAllergensAction` then becomes redundant for the form path and is only useful for future programmatic callers. We keep it for cleanliness but the admin form does not use it. Re-evaluate if it remains unused at the end of the implementation.
+
+**Schema update:**
+```typescript
+// src/features/products/schema.ts
+import { allergenCodeSchema } from "@/features/allergens/schema";
+
+export const updateProductSchema = z.object({
+  ...productSchema.shape,
+  categoryId: z.string().nullable(),
+  imageId: z.string().nullable(),
+  allergenCodes: z.array(allergenCodeSchema),   // new
+});
+```
+
+**Action update** (`src/features/products/api/actions.ts:updateProductAction`):
+- Persist `allergenCodes` alongside other fields in the same `db.update().set({...})` call.
+- No new cache tag needed; existing `updateTag("products")` covers PDP.
+
+### 5. Wire PDP
+
+**File:** `src/app/(public)/(pages)/product/[slug]/page.tsx`
+
+1. Fetch allergens reference list alongside the product (parallel):
+   ```typescript
+   const [result, allAllergens] = await Promise.all([
+     getProductBySlug(slug),
+     getAllergens(),
+   ]);
+   ```
+2. Insert `<AllergenList codes={result.allergenCodes} allergens={allAllergens} />` between the description block (line 277) and the `<Separator />` before `AddWithQuantityButton` (line 279).
+
+The component returns `null` for empty arrays so unset products render unchanged.
+
+### 6. JSON-LD update (nice-to-have)
+
+The PDP already emits JSON-LD product structured data (around line 150). [Schema.org/Product](https://schema.org/Product) does not have a first-class allergen field, but [Schema.org/NutritionInformation](https://schema.org/NutritionInformation) is in scope for Phase D. **Skip for Phase A.** Note in the Phase D spec.
+
+---
+
+## File summary
+
+| Action | File |
+|---|---|
+| Edit | `src/db/schema.ts` — `allergens` table, `products.allergenCodes`, `order_items.unitCostCents` (**human approval required**) |
+| Create | `drizzle/NNNN_allergens.sql` — migration, manually append seed `INSERT`s |
+| Create | `src/features/allergens/schema.ts` |
+| Create | `src/features/allergens/api/queries.ts` |
+| Create | `src/features/allergens/api/actions.ts` |
+| Create | `src/features/allergens/lib/icons.ts` |
+| Create | `src/features/allergens/components/allergen-picker.tsx` |
+| Create | `src/features/allergens/components/allergen-list.tsx` |
+| Edit | `src/features/products/schema.ts` — add `allergenCodes` to `updateProductSchema` |
+| Edit | `src/features/products/api/actions.ts` — persist `allergenCodes` in `updateProductAction` |
+| Verify | `src/features/products/api/queries.ts` — `allergenCodes` flows through (no change expected) |
+| Edit | `src/app/(admin)/admin/products/[id]/_components/product-form.tsx` — wrap in `<Tabs>`, render `<AllergenPicker>` in Info tab |
+| Edit | `src/app/(admin)/admin/products/[id]/page.tsx` — pass `allergens` from `getAllergens()`, read `?tab=` |
+| Edit | `src/app/(public)/(pages)/product/[slug]/page.tsx` — render `<AllergenList>` |
+| Edit (pre-A) | `src/lib/auth/guards.ts` — add resource-scoped guards (`requireProductEdit`, `requireRecipeView`, `requireRecipeEdit`, `requireCostView`, `requireIngredientEdit`, `requireReportsView`) |
+| Edit (pre-A) | `src/lib/logger.ts` — add `ingredients`, `recipes`, `nutrition`, `reports` namespaces |
+| Edit | `docs/features-catalog.json` — add `allergens` feature entry, update `lastUpdated` |
+| Edit | `docs/database-schema.md` — document new table + columns |
+
+---
+
+## Constraints (from `CLAUDE.md`)
+
+- **No `db.transaction()`** — Phase A has only single-table writes, no constraint hit.
+- **No barrel files** — direct imports from each file path.
+- **No dynamic imports of internal modules.**
+- **Slovak language for user-facing text.**
+- **`requireProductEdit()` on the new server action** (admin + manager). Use the resource-scoped guards from pre-A scaffolding.
+- **`updateTag("products")` after the action.** See [arc overview cache tag matrix](./_arc-overview.md#5-cache-tag-matrix).
+- **Structured logging via `log.products.error()`.**
+- **Schema changes require human approval before editing `src/db/schema.ts`.**
+- **No `pnpm db:push`** — generate + migrate.
+
+---
+
+## Migration path to Phase D
+
+When Phase D ships ingredient-driven derivation:
+
+1. Phase D extends the Phase C resolver to derive allergens (`recipe → ingredient[] → allergenCodes`).
+2. A new query `getDerivedProductDisplay(productId)` returns derived allergens when the product has a recipe; otherwise falls back to the manual `allergenCodes` column.
+3. The `<AllergenList>` PDP component stays unchanged — only its upstream data source changes.
+4. The admin picker becomes **conditionally read-only** when a recipe is linked, with a banner pointing at the recipe. Editable for products without a recipe.
+5. A drift report at `/admin/recipes/drift` lists products where the manual list differs from the derived list — read-only diagnostic for the migration.
+
+**Important:** `products.allergenCodes` is **NOT dropped in Phase D**. It stays as the manual fallback for products without a recipe (resold packaged items, drinks, etc.). The column never goes away.
+
+---
+
+## Open questions for review
+
+1. **Icon set.** Lucide gives us "good enough" mappings for 10 of 14, but "sulphites", "sesame", and "molluscs" are stretched. Worth replacing with custom SVGs from a Slovak-bakery designer later, or sticking with lucide indefinitely?
+2. **Should the picker live in a tab or inline?** Current product form is a long single column. A new section is fine inline, but if the form is approaching scrollability limits we may want tabs (Info / Allergens / Pricing / Images).
+3. **Cache tag granularity.** Phase A invalidates the whole `products` tag on any allergen edit. Acceptable (allergen edits are rare). Per-slug tag (`product-{slug}`) only worth adding if Phase D + heavier traffic justifies it.
+4. **B2B PDP.** Confirming the same `<AllergenList>` renders unchanged on the B2B catalog product views, no separate path needed.
+
+None of these block implementation. They become decisions during the build.

--- a/docs/specs/erp-profitability-phase-e.md
+++ b/docs/specs/erp-profitability-phase-e.md
@@ -1,0 +1,459 @@
+# ERP Profitability Reports (Phase E) — Implementation Spec
+
+> **Read first:** [`_arc-overview.md`](./_arc-overview.md) for role guards (`requireReportsView`), cache tags, mobile expectations, and the pricing model (Phase E reports are accurate because cents/kg storage from Phase B is lossless for every realistic supplier price).
+
+## Overview
+
+Surface store-level and product-level profitability using the cost data snapshotted in Phase C and the price history captured in Phase B. Phase E is read-only — no new mutations, no schema changes (with one optional materialized-aggregates table for performance, off by default). It turns the data foundations of Phases A-D into actionable reports for owners and managers: revenue, cost, gross margin, margin %, ranked by store / product / category, with date-range filters and CSV export.
+
+This is the closing phase of the recipe-costing arc and the first concrete deliverable of the ERP P/L track described in the project's 7-phase roadmap.
+
+## Goals
+
+- For any date range, show **revenue, cost, gross margin, margin %** broken down by store and by product.
+- Surface the **per-product margin distribution** so admins know which products subsidize which.
+- Show **ingredient price trends** with a chart and a list of products affected by each change.
+- Export each report to **CSV** (Excel-compatible) for accountants.
+- Add a small **profitability summary widget** to the existing admin dashboard.
+- Handle pre-Phase-C orders (no `unitCostCents`) gracefully — surface them as "Náklady nesledované" rather than zero-cost.
+- Performance: every report renders under 2s on the current order volume; degrade gracefully as the dataset grows.
+
+## Non-goals
+
+- Net profit (overhead, salaries, rent, utilities). Phase E is **gross margin only**: revenue minus product cost. Operating expenses are a Phase 4/6 concern in the ERP roadmap.
+- Forecasting / trend prediction.
+- Multi-currency.
+- Tax / VAT decomposition. Reports use the values already stored on `order_items.price` and `unitCostCents` — whatever convention the project uses (gross or net) is preserved.
+- Custom report builder. Phase E ships a fixed set of canned reports.
+- Real-time streaming. Reports are point-in-time queries with caching, not live dashboards.
+- Backfill of pre-Phase-C order costs (would be misleading — recipe + ingredient prices have changed).
+
+---
+
+## Prerequisites
+
+- Phase A pre-A scaffolding — `order_items.unitCostCents` column exists, `requireReportsView` guard, `reports` logger namespace.
+- Phase C — `order_items.unitCostCents` is being **populated** at order creation. (The column exists since Phase A; Phase C is the first writer.)
+- Phase B — `ingredient_price_history` populated with the lossless cents/kg storage. See [arc overview §3](./_arc-overview.md#3-pricing-model-canonical).
+- Phases A and D are not strictly required but most reports become more interesting with the full data.
+
+---
+
+## What to build
+
+### 1. Schema changes
+
+**Default: none.** All reports are computed from existing tables (`orders`, `order_items`, `products`, `stores`, `categories`, `ingredients`, `ingredient_price_history`).
+
+**Optional (off by default):** a single materialized-aggregates table for daily snapshots. Recommended only when the read query starts to drag. Spec it now so the migration is ready when the day comes:
+
+```typescript
+// Disabled by feature flag REPORTS_DAILY_SNAPSHOT until needed
+export const orderDailySnapshots = pgTable(
+  "order_daily_snapshots",
+  {
+    id: text("id").primaryKey().$defaultFn(() => createPrefixedId("ods")),
+    day: date("day").notNull(),                    // YYYY-MM-DD
+    storeId: text("store_id").references(() => stores.id, { onDelete: "set null" }),
+    productId: text("product_id").references(() => products.id, { onDelete: "set null" }),
+    quantity: integer("quantity").notNull(),
+    revenueCents: integer("revenue_cents").notNull(),
+    costCents: integer("cost_cents"),              // null when any underlying row had null unitCostCents
+    orderCount: integer("order_count").notNull(),
+    computedAt: timestamp("computed_at").defaultNow().notNull(),
+  },
+  (t) => [
+    unique("ods_day_store_product").on(t.day, t.storeId, t.productId),
+    index("idx_ods_day").on(t.day),
+    index("idx_ods_store_day").on(t.storeId, t.day),
+  ]
+);
+```
+
+Populated by a nightly cron action (Vercel Cron or similar). Off in Phase E unless reports start timing out — flag it in the spec rather than building speculatively.
+
+---
+
+### 2. Reports feature module: `src/features/reports/`
+
+```
+src/features/reports/
+├── api/
+│   ├── queries.ts                  # all SQL aggregations
+│   └── exports.ts                  # CSV serialization
+├── components/
+│   ├── reports-shell.tsx           # shared layout (header, date-range, store filter)
+│   ├── period-picker.tsx           # date range with presets (7d / 30d / 90d / MTD / custom)
+│   ├── store-filter.tsx
+│   ├── store-pl-table.tsx
+│   ├── product-pl-table.tsx
+│   ├── ingredient-trends-chart.tsx
+│   ├── ingredient-impact-list.tsx
+│   ├── margin-distribution-chart.tsx
+│   ├── kpi-card.tsx                # tržby / náklady / marža summary cards
+│   ├── period-comparison-row.tsx   # current vs previous period chips
+│   └── dashboard-profit-widget.tsx # used on /admin landing page
+└── lib/
+    ├── period.ts                   # parsing/normalizing date-range params
+    ├── format.ts                   # margin %, deltas, formatPrice integration
+    └── constants.ts                # INCLUDED_ORDER_STATUSES etc.
+```
+
+#### `lib/constants.ts`
+
+```typescript
+import type { OrderStatus } from "@/db/types";
+
+// Orders that count toward revenue + cost. Cancelled/refunded excluded.
+export const PROFIT_ORDER_STATUSES: OrderStatus[] = [
+  "new", "in_progress", "ready_for_pickup", "completed",
+];
+
+export const PERIOD_PRESETS = ["7d", "30d", "90d", "mtd", "ytd", "custom"] as const;
+export type PeriodPreset = (typeof PERIOD_PRESETS)[number];
+```
+
+`PROFIT_ORDER_STATUSES` is the project's default for "what counts as a sale." If business wants to exclude `new` and `in_progress` (uncompleted) the array is the single place to change. Document this.
+
+#### `api/queries.ts`
+
+All queries `"use cache"` with `cacheLife("hours")` and tagged `reports` plus a per-report scope. Re-cached automatically on order writes via the existing `orders` tag — extend `revalidateTag("reports")` calls to the order creation paths in Phase E (one-line change in `create-b2c-order.ts`).
+
+| Query | Inputs | Returns | Tags |
+|---|---|---|---|
+| `getStoreProfitability(period, opts: { storeIds?, segment? })` | date range + optional store filter (multi-store) + B2C/B2B segment | `Array<{ storeId, storeName, revenueCents, costCents, marginCents, marginPct, orderCount, untrackedCostOrderCount }>` | `reports`, `reports-stores` |
+| `getProductProfitability(period, opts: { storeIds?, categoryId?, minOrders?, segment? })` | date range + filters | `Array<{ productId, productName, categoryName, quantitySold, revenueCents, costCents, marginCents, marginPct }>` | `reports`, `reports-products` |
+| `getIngredientPriceTrends(ingredientId, period)` | one ingredient + date range | `Array<{ effectiveFrom, pricePerKgCents \| null, pricePerPieceCents \| null, deltaPct }>` | `reports`, `reports-ingredients-${ingredientId}` |
+| `getIngredientImpact(ingredientId)` | one ingredient | `Array<{ recipeId, recipeName, products: Array<{ productId, productName, contributionPctOfCost }> }>` | `reports`, `reports-ingredient-impact-${ingredientId}` |
+| `getMarginDistribution(period, opts: { storeIds?, segment? })` | date range | bucketed counts: `{ negative, 0to10, 10to30, 30to50, over50 }` | `reports`, `reports-distribution` |
+| `getProfitabilitySummary(period, opts: { storeIds?, segment? })` | date range | `{ revenueCents, costCents, marginCents, marginPct, untrackedShare }` for the dashboard widget | `reports`, `reports-summary` |
+| `getProfitabilityComparison(period, opts: { storeIds?, segment? })` | date range | `{ current, previous }` summaries for period-over-period | `reports`, `reports-summary` |
+
+All queries gated to `requireReportsView()` at the page level; queries themselves are pure read functions.
+
+**Filter shape future-proofing:** every query accepts `storeIds?: string[]` and `segment?: 'b2c' | 'b2b' | 'all'` from day one. Phase E doesn't enforce per-staff store scoping (UI exposes all stores). When Phase 4 introduces store-staff assignments, the `requireReportsView` guard returns the staff member's permitted store IDs, and the page automatically passes them to every query. Zero query-signature changes at that point. Same logic for `segment` once B2B orders launch.
+
+#### Sample SQL (store P&L)
+
+The shape that drives the rest of the queries:
+
+```sql
+SELECT
+  o.store_id,
+  s.name AS store_name,
+  COUNT(DISTINCT o.id) AS order_count,
+  SUM(oi.price * oi.quantity) AS revenue_cents,
+  SUM(oi.unit_cost_cents * oi.quantity) FILTER (WHERE oi.unit_cost_cents IS NOT NULL) AS cost_cents,
+  COUNT(DISTINCT o.id) FILTER (WHERE oi.unit_cost_cents IS NULL) AS untracked_cost_order_count
+FROM orders o
+JOIN order_items oi ON oi.order_id = o.id
+LEFT JOIN stores s ON s.id = o.store_id
+WHERE o.created_at >= $1
+  AND o.created_at < $2
+  AND o.order_status = ANY($3)            -- PROFIT_ORDER_STATUSES
+  AND ($4::text[] IS NULL OR o.store_id = ANY($4))
+GROUP BY o.store_id, s.name
+ORDER BY revenue_cents DESC NULLS LAST;
+```
+
+Key patterns reused across queries:
+- **`FILTER (WHERE oi.unit_cost_cents IS NOT NULL)`** so NULL costs don't poison the SUM. The complementary count surfaces how much of the period is "untracked".
+- **Status filter** uses the constant array, parameterized.
+- **NULL-safe store** because `orders.storeId` may be null (existing schema choice).
+
+In Drizzle, written via `sql` tagged template + `.execute()` for the FILTER aggregate (Drizzle's query builder doesn't express `FILTER` cleanly).
+
+---
+
+### 3. Routes
+
+#### `/admin/reports` — index
+
+`src/app/(admin)/admin/reports/page.tsx`
+
+Server component, `requireStaff()`. Lists the available reports as cards with a one-line description and a CTA button. Three cards in Phase E:
+- "Ziskovosť predajní" → `/admin/reports/profitability/stores`
+- "Ziskovosť produktov" → `/admin/reports/profitability/products`
+- "Trendy cien surovín" → `/admin/reports/ingredients`
+
+Top of the page: KPI strip showing the last-30-days summary (`getProfitabilitySummary`) so the index is informative on its own.
+
+#### `/admin/reports/profitability/stores`
+
+Server component. Uses `<ReportsShell>` to host the period picker + store filter. Renders:
+- KPI cards: total revenue, total cost, total margin, margin %
+- Period comparison row (current vs previous identical-length period)
+- `<StorePLTable>` — sortable, columns: store, orders, revenue, cost, margin, margin %, untracked cost orders
+- "Stiahnuť CSV" button → calls export action with current filters
+
+Empty state: "V zvolenom období neboli žiadne objednávky." No errors for sparse data.
+
+#### `/admin/reports/profitability/products`
+
+Same shell. Renders:
+- KPI strip
+- `<MarginDistributionChart>` — histogram showing how many products fall in each margin bucket (negative / 0-10% / 10-30% / 30-50% / >50%)
+- `<ProductPLTable>` — paginated, default sort by margin asc (worst first), filters: category, store, "min predajov" (hide products with very low volume to reduce noise)
+
+#### `/admin/reports/ingredients`
+
+`src/app/(admin)/admin/reports/ingredients/page.tsx` lists every ingredient with most-recent price + delta from previous price. Click → `/admin/reports/ingredients/[id]`:
+- Period picker
+- `<IngredientTrendsChart>` — line chart of price over time (`getIngredientPriceTrends`)
+- `<IngredientImpactList>` — for the current price, every recipe that uses this ingredient + the share of recipe cost it represents + the linked products
+
+This page is the "what happens if our supplier raises flour prices" tool. Without it, ingredient cost changes are invisible to non-technical staff.
+
+---
+
+### 4. Components
+
+#### `<ReportsShell>`
+
+Wraps every report page. Provides header (title, breadcrumb), period picker, store filter, action buttons (CSV export, refresh).
+
+State lives in URL search params (`?from=2026-01-01&to=2026-01-31&storeId=...`) so reports are linkable and the back button works. Server components read `searchParams` directly; client component only handles navigation.
+
+#### `<PeriodPicker>`
+
+`"use client"`. Presets row (7d / 30d / 90d / MTD / YTD / Custom). Custom opens a calendar `<Popover>` with two-date selection. Default: last 30 days. Writes to URL via `router.push()`.
+
+Calendar uses the existing `<Calendar>` shadcn component (date-fns under the hood, which the project already standardizes on).
+
+#### `<KPICard>`
+
+Single-metric card with optional delta vs previous period:
+
+```
+┌──────────────────────┐
+│ Tržby                │
+│ 12 480 €             │
+│ ▲ 8,2 % vs predchádz.│
+└──────────────────────┘
+```
+
+Delta direction is colored (green up / red down) but kept subdued — accounting reports get loud quickly otherwise.
+
+#### `<StorePLTable>` / `<ProductPLTable>`
+
+Both built on shadcn `DataTable`. Sortable columns, server-side sorting (URL params for column + direction). No client-side filtering — the URL is the source of truth.
+
+Margin column shows both absolute (€) and percentage. Margin % is colored on a three-tier scale: red (< 10%), amber (10-30%), green (≥ 30%). Thresholds in `lib/constants.ts` for easy tweaking.
+
+A tooltip on the "Untracked cost orders" count explains: "X objednávok bolo vytvorených pred zavedením sledovania nákladov a do nákladov sa nepočítajú."
+
+#### Charts
+
+- `<IngredientTrendsChart>` — line chart, recharts (consistent with Tremor / shadcn chart conventions). X axis: date, Y axis: price/base unit in EUR.
+- `<MarginDistributionChart>` — bar chart, 5 bins.
+
+If the project doesn't already have a chart primitive, use the shadcn `<ChartContainer>` from `src/components/ui/chart.tsx` (recharts-based).
+
+#### `<DashboardProfitWidget>`
+
+Drop-in card for the existing admin dashboard at `/admin`. Shows the last-30-days profitability summary using `getProfitabilitySummary` + a small sparkline of daily margin. One CTA: "Otvoriť reporty →".
+
+This is the entry point — admins shouldn't have to navigate to "Reports" to see whether the bakery made money this month.
+
+---
+
+### 5. CSV export
+
+#### `api/exports.ts`
+
+```typescript
+export async function exportStoreProfitabilityCsv(period: Period, storeIds?: string[]): Promise<string>;
+export async function exportProductProfitabilityCsv(period: Period, opts: ProductFilters): Promise<string>;
+```
+
+Each function:
+1. Calls the corresponding query
+2. Serializes to CSV with semicolon delimiter (Slovak Excel default), UTF-8 BOM prefix (so `Č/Š/Ž` render correctly in Excel)
+3. Returns the CSV string
+
+#### Export endpoint
+
+`src/app/api/admin/reports/export/route.ts` — GET handler that:
+1. `requireStaff()` (server-side guard, not just a UI button)
+2. Reads `?report=stores|products` + period + filters
+3. Calls the appropriate export function
+4. Returns `Response` with `Content-Type: text/csv; charset=utf-8` and a `Content-Disposition: attachment; filename="reporty-predajne-2026-05-01_2026-05-31.csv"` header
+
+Date-range and store IDs in the filename so downloads don't collide. Filename is human-readable (Slovak diacritics-free).
+
+Excel doesn't open `.xlsx` from a CSV. If a true Excel file becomes a requirement later, the project already documents `xlsx` as the lazy-loaded library option in `CLAUDE.md`.
+
+---
+
+### 6. Caching strategy
+
+| Tag | Set by | Invalidated by |
+|---|---|---|
+| `reports` | All report queries | Order creation, order status change, ingredient price update, recipe edit |
+| `reports-summary` | `getProfitabilitySummary` | Same as `reports` |
+| `reports-stores` | `getStoreProfitability` | Same |
+| `reports-products` | `getProductProfitability` | Same |
+| `reports-ingredients-${id}` | `getIngredientPriceTrends` | Ingredient price update |
+| `reports-ingredient-impact-${id}` | `getIngredientImpact` | Recipe edit, ingredient price update |
+| `reports-distribution` | `getMarginDistribution` | Order creation, recipe edit |
+
+`cacheLife("hours")` everywhere — reports change rarely, and reports rendering inside an admin context tolerates a small staleness window. If business requests "real-time," tighten to `cacheLife("minutes")` selectively.
+
+The order creation action (`src/features/orders/actions/create-b2c-order.ts`) gets `revalidateTag("reports")` appended to its existing tag list. Same for order status changes and (where Phase B/C don't already do so) ingredient price updates.
+
+---
+
+### 7. Handling missing cost data
+
+Three categories of orders need explicit handling:
+
+1. **Pre-Phase-C orders** — `unitCostCents IS NULL` for every line. Excluded from cost SUM via `FILTER`. Counted into `untrackedCostOrderCount`. Surfaced to the user as a small note on every report: "Z dôvodu zavedenia sledovania nákladov v máji 2026 niektoré staršie objednávky neobsahujú dáta o nákladoch."
+
+2. **Orders with mixed cost coverage** — some line items had a recipe at order time, some didn't. The cost SUM ignores the NULL lines but revenue still includes them. This makes margin % an underestimate for that order. Acceptable in aggregate; spec doesn't compensate.
+
+3. **Cancelled / refunded orders** — excluded by `PROFIT_ORDER_STATUSES`. If business wants to see refund volume separately, add a Phase F report. Not in Phase E.
+
+A small admin tool at `/admin/reports/diagnostics` (read-only) shows the breakdown:
+- % of orders with full cost coverage
+- % with partial coverage
+- % with none
+
+Useful when admins ask "why is margin % weird?" — points them at the data quality issue rather than the calculation.
+
+---
+
+### 8. Performance
+
+Expected order volume (per project context: small bakery chain, several stores): < 1000 orders/day → < 365k orders/year. `order_items` ~5x that. PostgreSQL aggregations are fast at this scale. Existing indexes on `orders.created_at`, `orders.order_status`, `orders.store_id` cover the queries.
+
+Two indexes worth verifying / adding (no schema migration if they already exist):
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_orders_status_created_at
+  ON orders (order_status, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_order_items_order_product
+  ON order_items (order_id, product_id);
+```
+
+The first is the hot path for every report. The second supports the product-level join.
+
+If a report ever exceeds 2s p95, the optional `order_daily_snapshots` table (Section 1) becomes the answer. Don't pre-optimize.
+
+---
+
+### 9. Admin nav + dashboard
+
+- `src/app/(admin)/admin/_components/sidebar.tsx` — add a new top-level "Reporty" section with the three report links.
+- `src/app/(admin)/admin/(dashboard)/page.tsx` — append `<DashboardProfitWidget>` to the existing dashboard layout.
+
+Visible to `admin` and `manager`. Once the baker role exists (Phase 4), bakers do not see reports — production cost is sensitive operational data, not production-floor information.
+
+---
+
+## File summary
+
+| Action | File |
+|---|---|
+| (Optional) Edit | `src/db/schema.ts` — `order_daily_snapshots` table behind feature flag (**human approval if enabled**) |
+| Create | `src/features/reports/api/queries.ts` |
+| Create | `src/features/reports/api/exports.ts` |
+| Create | `src/features/reports/lib/period.ts` |
+| Create | `src/features/reports/lib/format.ts` |
+| Create | `src/features/reports/lib/constants.ts` |
+| Create | `src/features/reports/components/reports-shell.tsx` |
+| Create | `src/features/reports/components/period-picker.tsx` |
+| Create | `src/features/reports/components/store-filter.tsx` |
+| Create | `src/features/reports/components/store-pl-table.tsx` |
+| Create | `src/features/reports/components/product-pl-table.tsx` |
+| Create | `src/features/reports/components/ingredient-trends-chart.tsx` |
+| Create | `src/features/reports/components/ingredient-impact-list.tsx` |
+| Create | `src/features/reports/components/margin-distribution-chart.tsx` |
+| Create | `src/features/reports/components/kpi-card.tsx` |
+| Create | `src/features/reports/components/period-comparison-row.tsx` |
+| Create | `src/features/reports/components/dashboard-profit-widget.tsx` |
+| Create | `src/app/(admin)/admin/reports/page.tsx` |
+| Create | `src/app/(admin)/admin/reports/profitability/stores/page.tsx` |
+| Create | `src/app/(admin)/admin/reports/profitability/products/page.tsx` |
+| Create | `src/app/(admin)/admin/reports/ingredients/page.tsx` |
+| Create | `src/app/(admin)/admin/reports/ingredients/[id]/page.tsx` |
+| Create | `src/app/(admin)/admin/reports/diagnostics/page.tsx` |
+| Create | `src/app/api/admin/reports/export/route.ts` |
+| Edit | `src/features/orders/actions/create-b2c-order.ts` — add `revalidateTag("reports")` |
+| Edit | `src/features/orders/api/actions.ts` (status change) — add `revalidateTag("reports")` |
+| Edit | `src/features/ingredients/api/actions.ts` — add `revalidateTag("reports")` on price changes |
+| Edit | `src/features/recipes/api/actions.ts` — add `revalidateTag("reports")` on recipe item edits |
+| Edit | `src/app/(admin)/admin/_components/sidebar.tsx` — "Reporty" nav section |
+| Edit | `src/app/(admin)/admin/(dashboard)/page.tsx` — mount `<DashboardProfitWidget>` |
+| Verify | indexes `idx_orders_status_created_at`, `idx_order_items_order_product` exist; add migration if missing |
+| Edit | `docs/database-schema.md` — note the indexes (and snapshots table if enabled) |
+| Edit | `docs/features-catalog.json` — new `reports` feature, update `lastUpdated` |
+| Edit | `CLAUDE.md` — note the Reports module under feature modules list |
+
+---
+
+## Constraints
+
+- **No `db.transaction()`** — Phase E is read-only; not a concern.
+- **No barrel files** — direct imports.
+- **No dynamic imports of internal modules** — recharts is third-party, fine to static-import.
+- **Slovak language** for user-facing text; code in English.
+- **`requireReportsView()`** on every page and the export route (admin + manager; bakers do not see reports). Resource-scoped guard from pre-A scaffolding. See [arc overview §4](./_arc-overview.md#4-role-matrix).
+- **Schema changes require human approval** before editing `src/db/schema.ts` (only relevant if the optional snapshots table is enabled).
+- **No `pnpm db:push`** — generate + migrate.
+- **Money in cents**, **margin % to 1 decimal**, EUR-only.
+- **Structured logging** via `log.reports.error()` — add new module logger.
+- **`cacheLife("hours")` + `cacheTag()`** on all queries; mutations across orders/ingredients/recipes invalidate via `revalidateTag("reports")`.
+
+---
+
+## Open questions / decisions to lock
+
+1. **Net vs gross prices.** Reports use whatever's stored on `order_items.price` and `unitCostCents`. Confirm whether these are gross (incl. VAT) or net so the labels match. If they differ, a single divisor in `lib/format.ts` solves it. (Decision is held centrally in [arc overview §12.1](./_arc-overview.md#12-open-questions-kept-here-so-phase-specs-dont-drift).)
+2. **Status set for "counts as a sale."** Default per [arc overview §12.4](./_arc-overview.md#12-open-questions-kept-here-so-phase-specs-dont-drift): `PROFIT_ORDER_STATUSES = ["new", "in_progress", "ready_for_pickup", "completed"]`.
+3. **Refunds reporting.** Phase E excludes `cancelled`/`refunded`. A separate "Refundy" report (or a column on the store P&L table) is a cheap add — flag for Phase F.
+4. **Snapshot table opt-in trigger.** Recommend enabling `order_daily_snapshots` only when a report exceeds 2s p95 in observed admin usage. Premature now.
+5. **Comparison period semantics.** Period-over-period default: identical-length window immediately before. Year-over-year would also be useful but doubles the query count. Defer.
+6. **Public-facing margin display.** Never. Costs and margins are internal-only. Reports are admin-route exclusive.
+7. **B2B vs B2C split.** Query signatures already accept `segment` (see the filter shape future-proofing above). UI exposes it once B2B order creation launches; until then, `segment` defaults to `'all'` and silently means "B2C only" because that's all that exists.
+
+---
+
+## Performance notes
+
+- Expected p95 query time on current dataset: < 500ms for store P&L, < 1s for product P&L, < 200ms for summary widget. Margins will erode as the orders table grows; revisit at 100k+ orders/month.
+- CSV export streams the full result; no pagination. At expected volumes (max ~5000 product rows for a year of data), this is fine. If it ever balloons, swap to a streamed `Response` body.
+- `cacheLife("hours")` means the dashboard widget could be up to an hour stale. Acceptable. Tighten only if business asks.
+- Recharts is a 70 KB-ish addition if the project doesn't already use it. Worth it; lighter alternatives (uplot, observable plot) trade ergonomics. Stick with the shadcn-blessed default.
+
+---
+
+## Acceptance criteria
+
+- [ ] `/admin/reports` index renders and shows last-30-days summary
+- [ ] Store P&L report shows revenue, cost, margin, margin %, with period picker working across presets and custom range
+- [ ] Product P&L report sorts by margin and supports category + store filters
+- [ ] Ingredient trends chart renders for any ingredient with at least one price-history entry
+- [ ] Ingredient impact list shows the recipes (and their products) that use a selected ingredient
+- [ ] CSV export downloads with semicolon delimiter, UTF-8 BOM, Slovak filename
+- [ ] Pre-Phase-C orders are excluded from cost SUMs but counted into the "untracked" tooltip
+- [ ] Period-over-period delta shown on KPI cards, color-coded
+- [ ] Dashboard widget mounts on `/admin`, links to reports
+- [ ] Reports invalidate within seconds of an order being created / status changing
+- [ ] All pages and the export route guarded by `requireStaff()`
+- [ ] No barrel files; no dynamic imports of internal modules; structured logging via `log.reports`
+
+---
+
+## Out of scope
+
+- Net profit / operating expenses / overhead allocation
+- Forecasting / predictive analytics
+- Multi-currency
+- Custom report builder
+- Real-time / streaming reports
+- Cost backfill for pre-Phase-C orders
+- B2B-segment-only reports (until B2B orders launch)
+- Email / Slack digest of weekly margins (easy add later via cron)
+- Per-staff-member productivity reports (different domain)
+- VAT decomposition

--- a/docs/specs/ingredients-phase-b.md
+++ b/docs/specs/ingredients-phase-b.md
@@ -1,0 +1,756 @@
+# Ingredients Catalog (Phase B) — Implementation Spec
+
+> **Read first:** [`_arc-overview.md`](./_arc-overview.md) for the canonical pricing model, role guards, cache tags, fuzzy search, and cross-cutting non-goals.
+
+## Overview
+
+Build the ingredients catalog — the raw-materials database that backs recipes (Phase C) and nutrition derivation (Phase D). Admin gets full CRUD over ingredients with name, base unit (`g` or `piece`), price (stored as cents/kg or cents/piece, entered in any supplier-natural unit), nutrition values per 100 g, allergen tags, and optional supplier info. A separate price-history table records cost changes over time so future ERP reports can analyze margin trends without losing fidelity.
+
+This phase is admin-only — no public-facing or B2B changes. Phase B is a foundation: nothing in it is visible to customers until Phase C wires recipes and Phase D computes nutrition.
+
+Phase B includes two pieces that were originally scheduled for Phase D, brought forward because they collapse the dominant data-entry bottleneck:
+
+1. **AI nutrition autofill** — body of the Claude SDK call (Phase D originally).
+2. **Fuzzy search + duplicate detection** — pg_trgm-powered ingredient picker and a `/admin/ingredients/duplicates` review tool.
+
+## Goals
+
+- Admin can create, edit, list, search (fuzzy, diacritic-free), and (soft-)deactivate ingredients.
+- Each ingredient has a single base unit: `g` or `piece`. No `ml`.
+- Price is stored as integer cents per kg (mass) or per piece (piece), normalized from any supplier-natural input unit.
+- Allergen tagging via the Phase A `allergens` reference table.
+- Nutrition values per 100 g entered manually OR via the AI autofill flow (Claude SDK, admin confirms before persist).
+- Duplicate detection at create time — type "Hladka muka" and see existing "Hladká múka T650" as a suggestion before saving a dup.
+- Price changes are written to `ingredient_price_history` automatically so historical cost reconstruction works.
+- Seeded bakery ingredient list (~50 entries) — names + allergens + base unit only. Prices and nutrition are filled by admins through the form (price) and AI autofill (nutrition), not in the seed.
+
+## Non-goals
+
+- Multi-supplier price comparison per ingredient (single current supplier name; one historical row per change).
+- Inventory tracking (stock levels, expiry, reorder points). Out of scope until ERP Phase 4 store-manager wave.
+- Unit conversion to `ml` (deliberately dropped — see Phase A spike). Liquids stored in grams.
+- Automatic price imports from supplier feeds. Manual entry only.
+- Vector embeddings for semantic ingredient search. pg_trgm covers our scale. See [arc overview §9](./_arc-overview.md#9-fuzzy-search--duplicate-detection).
+- Bulk CSV import.
+- Any public-facing display.
+
+---
+
+## Prerequisites
+
+- Phase A allergens reference table (`allergens` with `code` PK and seeded EU 14 rows). Required for the `<AllergenPicker>` reuse and for FK semantics on `ingredients.allergenCodes`.
+- Pre-A scaffolding: role guards (`requireIngredientEdit`), `ingredients` module logger. See [arc overview §2](./_arc-overview.md#2-pre-a-scaffolding-do-this-once).
+- `ANTHROPIC_API_KEY` env var (for AI nutrition autofill). Document in `.env.example`. The form gracefully disables the AI button when the key is missing.
+
+---
+
+## What to build
+
+### 1. Schema changes (`src/db/schema.ts`) — REQUIRES HUMAN APPROVAL
+
+#### Postgres extensions
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS unaccent;
+```
+
+Added at the top of Phase B's migration. `pg_trgm` powers the fuzzy ingredient search and duplicate detection; `unaccent` strips diacritics so "muka" matches "múka". See [arc overview §9](./_arc-overview.md#9-fuzzy-search--duplicate-detection).
+
+#### New table: `ingredients`
+
+The pricing model uses two **XOR** columns (`pricePerKgCents` or `pricePerPieceCents`), enforced by CHECK. See [arc overview §3](./_arc-overview.md#3-pricing-model-canonical) for the full rationale — per-kg storage is lossless for every realistic supplier price; per-gram and per-100g aren't.
+
+```typescript
+export const INGREDIENT_BASE_UNITS = ["g", "piece"] as const;
+export const INGREDIENT_NUTRITION_SOURCES = ["manual", "ai", "supplier", "seed"] as const;
+
+export const ingredients = pgTable(
+  "ingredients",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createPrefixedId("ing")),
+    name: text("name").notNull().default("Nová surovina"),
+    slug: text("slug")
+      .notNull()
+      .unique()
+      .$defaultFn(() => draftSlug("Nová surovina")),
+
+    baseUnit: text("base_unit")
+      .$type<(typeof INGREDIENT_BASE_UNITS)[number]>()
+      .notNull()
+      .default("g"),
+    gramsPerPiece: integer("grams_per_piece"),  // required when baseUnit = 'piece'
+
+    // Pricing — exactly one is non-null, enforced by CHECK below
+    pricePerKgCents: integer("price_per_kg_cents"),       // when baseUnit = 'g'
+    pricePerPieceCents: integer("price_per_piece_cents"), // when baseUnit = 'piece'
+
+    supplierName: text("supplier_name"),
+
+    allergenCodes: text("allergen_codes")
+      .array()
+      .notNull()
+      .default(sql`ARRAY[]::text[]`),
+
+    nutritionPer100: jsonb("nutrition_per_100").$type<NutritionPer100>(),
+    nutritionSource: text("nutrition_source")
+      .$type<(typeof INGREDIENT_NUTRITION_SOURCES)[number]>()
+      .notNull()
+      .default("manual"),
+
+    notes: text("notes"),
+    isActive: boolean("is_active").notNull().default(true),
+
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (t) => [
+    index("idx_ingredients_slug").on(t.slug),
+    index("idx_ingredients_active").on(t.isActive),
+    // Trigram GIN index for fuzzy + duplicate-suggestion queries
+    sql`CREATE INDEX idx_ingredients_name_trgm ON ${t} USING gin (lower(unaccent(name)) gin_trgm_ops)`,
+
+    check("ingredients_price_kg_non_negative",   sql`${t.pricePerKgCents} IS NULL OR ${t.pricePerKgCents} >= 0`),
+    check("ingredients_price_piece_non_negative", sql`${t.pricePerPieceCents} IS NULL OR ${t.pricePerPieceCents} >= 0`),
+    check(
+      "ingredients_grams_per_piece_when_piece",
+      sql`(${t.baseUnit} <> 'piece') OR (${t.gramsPerPiece} IS NOT NULL AND ${t.gramsPerPiece} > 0)`
+    ),
+    // Price column XOR: exactly one non-null, matching baseUnit
+    check(
+      "ingredients_price_matches_base_unit",
+      sql`(${t.baseUnit} = 'g'     AND ${t.pricePerKgCents}    IS NOT NULL AND ${t.pricePerPieceCents} IS NULL)
+       OR (${t.baseUnit} = 'piece' AND ${t.pricePerPieceCents} IS NOT NULL AND ${t.pricePerKgCents}    IS NULL)`
+    ),
+  ]
+);
+```
+
+The trigram index is created via raw SQL because Drizzle's index DSL doesn't express `gin_trgm_ops` cleanly. Other indexes use the standard DSL.
+
+`NutritionPer100` is a TS type:
+
+```typescript
+export type NutritionPer100 = {
+  kcal: number;
+  protein: number;        // g
+  fat: number;            // g
+  saturatedFat: number;   // g
+  carbs: number;          // g
+  sugar: number;          // g
+  salt: number;           // g
+  fiber: number;          // g
+};
+```
+
+Stored as `jsonb` rather than separate columns to keep the row narrow and let the shape evolve (e.g., adding `vitaminD` later) without migrations. Indexed access is rare; we always read the whole nutrition blob.
+
+The CHECK `ingredients_grams_per_piece_when_piece` enforces the conditional requirement at DB level. The Zod schema validates the same on input.
+
+#### New table: `ingredient_price_history`
+
+Append-only log. One row per price change. Mirrors the same two-column XOR shape as `ingredients` so historical reconstruction needs zero conversion.
+
+```typescript
+export const ingredientPriceHistory = pgTable(
+  "ingredient_price_history",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createPrefixedId("iph")),
+    ingredientId: text("ingredient_id")
+      .notNull()
+      .references(() => ingredients.id, { onDelete: "cascade" }),
+    // Mirrors the ingredients table's pricing shape
+    pricePerKgCents: integer("price_per_kg_cents"),
+    pricePerPieceCents: integer("price_per_piece_cents"),
+    supplierName: text("supplier_name"),
+    source: text("source").default("manual").notNull(),  // 'manual' | 'import' | 'seed' | 'ai'
+    notes: text("notes"),
+    effectiveFrom: timestamp("effective_from").defaultNow().notNull(),
+  },
+  (t) => [
+    index("idx_iph_ingredient_effective").on(t.ingredientId, t.effectiveFrom),
+    check("iph_price_kg_non_negative",    sql`${t.pricePerKgCents}    IS NULL OR ${t.pricePerKgCents}    >= 0`),
+    check("iph_price_piece_non_negative", sql`${t.pricePerPieceCents} IS NULL OR ${t.pricePerPieceCents} >= 0`),
+    check(
+      "iph_price_xor",
+      sql`(${t.pricePerKgCents} IS NOT NULL AND ${t.pricePerPieceCents} IS NULL)
+       OR (${t.pricePerPieceCents} IS NOT NULL AND ${t.pricePerKgCents}    IS NULL)`
+    ),
+  ]
+);
+```
+
+Updates to the ingredient's price are mirrored into this table by the action layer (no DB trigger — keep logic in app code where it's debuggable). **Ordering:** insert the price-history row FIRST, then update the ingredient. If history insert fails, abort the update — the audit log is the safer side to favour.
+
+#### Relations
+
+```typescript
+export const ingredientsRelations = relations(ingredients, ({ many }) => ({
+  priceHistory: many(ingredientPriceHistory),
+  // recipeItems link added in Phase C
+}));
+
+export const ingredientPriceHistoryRelations = relations(
+  ingredientPriceHistory,
+  ({ one }) => ({
+    ingredient: one(ingredients, {
+      fields: [ingredientPriceHistory.ingredientId],
+      references: [ingredients.id],
+    }),
+  })
+);
+```
+
+#### Migration steps
+
+1. `pnpm db:generate` — produces the migration.
+2. **Manually edit** the generated SQL to append the seed `INSERT` for the bakery ingredients ([seed data](#seed-data)). Each seed row also needs a corresponding `ingredient_price_history` row with `source = 'seed'` and `effectiveFrom = now()`.
+3. `pnpm db:migrate`.
+
+---
+
+### 2. Seed data
+
+Approximately 50 common Slovak bakery ingredients. Goal: recipe builder lands with a real catalog of **names + allergens + base unit + grams-per-piece**. Price and nutrition are admin-filled after the seed, not in the seed:
+
+- **Price**: every seed row inserts a placeholder `pricePerKgCents = 0` (or `pricePerPieceCents = 0` for eggs) and a flag/notes "Cena: doplniť". The list page filter "Bez ceny" surfaces them for batch entry.
+- **Nutrition**: every seed row has `nutritionPer100 = NULL` and `nutritionSource = 'seed'`. Admin uses the AI autofill flow (this same phase) to populate them one-by-one with confirmation. See [§7 AI nutrition autofill](#7-ai-nutrition-autofill).
+
+This split is deliberate: hardcoding 50 × 8 nutrition values into the migration is hours of brittle copy-paste from public sources. The AI flow takes ~50 clicks and gives admins a confirmation step.
+
+Categories to cover:
+- **Múky** (8): T550, T650, T1050, T1800, špaldová, ražná tmavá, ražná svetlá, kukuričná
+- **Tekutiny / mlieko** (6): voda, mlieko 1.5%, mlieko 3.5%, smotana 33%, kyslá smotana, cmar
+- **Cukry / sladidlá** (5): kryštálový cukor, práškový cukor, hnedý cukor, med, glukózový sirup
+- **Tuky** (5): maslo, sadlo, slnečnicový olej, olivový olej, repkový olej
+- **Vajcia** (1): vajce M (`baseUnit=piece`, `gramsPerPiece=50`, `allergenCodes=['eggs']`)
+- **Soli / koreniny** (5): morská soľ, jemná soľ, mletá rasca, mletý zázvor, vanilkový cukor
+- **Kysniace** (4): čerstvé droždie, sušené droždie, prášok do pečiva, sóda bikarbóna
+- **Orechy / semienka** (8): vlašské orechy, mandle, lieskovce, slnečnicové semienka, sezamové semienka, ľanové semienka, makové semienka, tekvicové semienka
+- **Sušené ovocie** (4): hrozienka, sušené brusnice, sušené marhule, sušené slivky
+- **Špeciality** (4): kakaový prášok, čokoláda 70%, mascarpone, syr Niva
+
+Each seed row carries:
+- `name`, `slug`
+- `baseUnit` + `gramsPerPiece` (only for vajce)
+- `allergenCodes` populated from EU 14 mapping (e.g. múka → `['gluten']`, mlieko → `['milk']`, vajce → `['eggs']`, mandle → `['tree_nuts']`)
+- `pricePerKgCents = 0` (or `pricePerPieceCents = 0` for eggs) — placeholder
+- `nutritionPer100 = NULL`
+- `nutritionSource = 'seed'`
+- `isActive = true`
+
+Seed lives in a TS file (`drizzle/seed/ingredients.ts`) imported by the migration generator script. Easier to maintain than raw SQL; final SQL is what gets committed.
+
+Each seed row also generates a corresponding `ingredient_price_history` row with the zero price and `source = 'seed'` so future ERP reports see a complete timeline starting from seed-time.
+
+---
+
+### 3. Feature module: `src/features/ingredients/`
+
+```
+src/features/ingredients/
+├── api/
+│   ├── queries.ts
+│   └── actions.ts
+├── components/
+│   ├── ingredient-form.tsx          # used standalone AND inside Phase C's Sheet
+│   ├── ingredients-table.tsx
+│   ├── ingredient-list-filters.tsx
+│   ├── nutrition-fields.tsx
+│   ├── price-input.tsx              # unit-aware input with normalization preview
+│   ├── price-history-panel.tsx
+│   ├── ingredient-status-badge.tsx
+│   ├── ai-suggestion-dialog.tsx     # review + confirm AI nutrition suggestion
+│   ├── duplicate-suggestion.tsx     # surfaced under the name field at create time
+│   └── duplicates-table.tsx         # /admin/ingredients/duplicates tool
+├── lib/
+│   ├── allergen-defaults.ts         # ingredient-name → allergen heuristics for autofill
+│   ├── format.ts                    # formatBaseUnit, formatPricePerUnit, formatPrice100g
+│   ├── price-conversion.ts          # admin-input unit → canonical cents/kg or cents/piece
+│   └── anthropic.ts                 # singleton SDK client + system prompt constants
+└── schema.ts
+```
+
+#### `schema.ts` — Zod
+
+```typescript
+import { z } from "zod";
+import { allergenCodeSchema } from "@/features/allergens/schema";
+
+export const INGREDIENT_BASE_UNITS = ["g", "piece"] as const;
+
+export const nutritionPer100Schema = z.object({
+  kcal: z.number().min(0).max(2000),
+  protein: z.number().min(0).max(100),
+  fat: z.number().min(0).max(100),
+  saturatedFat: z.number().min(0).max(100),
+  carbs: z.number().min(0).max(100),
+  sugar: z.number().min(0).max(100),
+  salt: z.number().min(0).max(100),
+  fiber: z.number().min(0).max(100),
+});
+
+export const ingredientSchema = z
+  .object({
+    name: z.string().trim().min(1, "Názov je povinný").max(100),
+    baseUnit: z.enum(INGREDIENT_BASE_UNITS),
+    gramsPerPiece: z.number().int().positive().nullable(),
+    pricePerKgCents: z.number().int().min(0).nullable(),
+    pricePerPieceCents: z.number().int().min(0).nullable(),
+    supplierName: z.string().trim().max(100).nullable(),
+    allergenCodes: z.array(allergenCodeSchema),
+    nutritionPer100: nutritionPer100Schema.nullable(),
+    notes: z.string().trim().max(2000).nullable(),
+    isActive: z.boolean(),
+  })
+  .refine(
+    (v) => v.baseUnit !== "piece" || (v.gramsPerPiece !== null && v.gramsPerPiece > 0),
+    {
+      message: "Pri jednotke 'kus' musí byť zadaná hmotnosť za kus",
+      path: ["gramsPerPiece"],
+    }
+  )
+  .refine(
+    (v) =>
+      (v.baseUnit === "g"     && v.pricePerKgCents    !== null && v.pricePerPieceCents === null) ||
+      (v.baseUnit === "piece" && v.pricePerPieceCents !== null && v.pricePerKgCents    === null),
+    {
+      message: "Cena musí byť zadaná v jednotke zodpovedajúcej baseUnit",
+      path: ["pricePerKgCents"],
+    }
+  );
+
+export type IngredientSchema = z.infer<typeof ingredientSchema>;
+
+export const updateIngredientSchema = ingredientSchema.extend({
+  id: z.string().min(1),
+});
+
+// AI autofill response shape
+export const aiNutritionSuggestionSchema = z.object({
+  ...nutritionPer100Schema.shape,
+  confidence: z.enum(["high", "medium", "low"]),
+  source: z.string().max(200),
+});
+
+export type AiNutritionSuggestion = z.infer<typeof aiNutritionSuggestionSchema>;
+```
+
+#### `api/queries.ts`
+
+All cached with `"use cache"`, `cacheLife("hours")`, tagged `"ingredients"` (and per-id where relevant). See [arc overview §5](./_arc-overview.md#5-cache-tag-matrix).
+
+| Query | Purpose | Cache tags |
+|---|---|---|
+| `getIngredients(opts?: { search?, isActive?, missingPrice?, missingNutrition? })` | List for admin table; `search` runs trigram match | `ingredients` |
+| `getIngredientById(id)` | Detail page + form | `ingredients`, `ingredient-${id}` |
+| `getIngredientPriceHistory(id, limit?)` | Last N price changes for the chart | `ingredient-${id}-prices` |
+| `getIngredientsForResolver()` | Lightweight Map of active ingredients used by Phase C resolver | `ingredients` |
+| `findSimilarIngredients(name, limit?)` | Trigram similarity for duplicate suggestion at create time | `ingredients` |
+| `getIngredientDuplicates(threshold?)` | Pairs above similarity threshold for the duplicates review page | `ingredients` |
+
+`getIngredientsForResolver()` is the bridge to Phase C — same idea as `getResolverContext()` over there, but the ingredient half. Returns only the columns the resolver needs (id, name, baseUnit, pricePerKgCents, pricePerPieceCents, allergenCodes, gramsPerPiece, nutritionPer100). Phase C's resolver context query JOINs this with recipes data.
+
+#### Fuzzy / similarity queries
+
+`findSimilarIngredients(name)` runs:
+
+```sql
+SELECT id, name, similarity(lower(unaccent(name)), lower(unaccent($1))) AS score
+FROM ingredients
+WHERE similarity(lower(unaccent(name)), lower(unaccent($1))) > 0.6
+ORDER BY score DESC
+LIMIT $2;
+```
+
+`getIngredients({ search })` runs a trigram match with a lower threshold (0.3) so the admin's typing always returns *something* useful, plus a fallback ILIKE for short queries (1-2 chars) where trigrams are unreliable.
+
+#### `api/actions.ts`
+
+All actions: `"use server"`, `await requireIngredientEdit()`, error-logged via `log.ingredients.error()`, `revalidateTag()` after success. See [arc overview §5](./_arc-overview.md#5-cache-tag-matrix).
+
+| Action | Input | Effect | Tags invalidated |
+|---|---|---|---|
+| `createIngredientAction` | `IngredientSchema` | Insert price-history row first, then insert ingredient. **Returns the new ingredient** (no redirect) so Phase C's inline-create flow can autofill the picker | `ingredients`, `recipes`, `reports` |
+| `updateIngredientAction` | `UpdateIngredientSchema` | If price changed: insert history row FIRST, then update ingredient. Otherwise: just update. | `ingredients`, `ingredient-${id}`; if price changed: `ingredient-${id}-prices`, `recipes`, `reports` |
+| `deleteIngredientAction` | `{ id }` | Hard delete only when no recipe items reference it (Phase C check via direct SQL); else returns `{ success: false, error: "Surovina je použitá v X receptoch", recipeIds: [...] }` | `ingredients`, `ingredient-${id}` |
+| `setIngredientActiveAction` | `{ id, isActive }` | Soft-deactivate; deactivated ingredients are filtered from Phase C picker but stay readable for old recipes | `ingredients`, `ingredient-${id}` |
+| `aiAutofillNutritionAction` | `{ ingredientId }` | Calls Claude API, returns suggestion (no DB write). Admin confirms via dialog; dialog calls `updateIngredientAction` with the values + `nutritionSource: 'ai'` | none (read-only) |
+
+Notable details:
+
+- **`createIngredientAction` deviates from the project pattern of redirecting after create.** Reason: Phase C's recipe builder needs the new ingredient back to update the picker. The standalone "Nová surovina" button on the list page does its own `router.push(/admin/ingredients/${ingredient.id})` after the action returns.
+- **Price-history ordering is reversed from the project's typical defensive pattern.** Insert the audit row FIRST, then update the ingredient. If the history insert fails, abort. Rationale: we'd rather have a history row without a current-price update (admin will retry, the change just didn't happen) than a current-price update without history (silent loss of audit trail, only noticed weeks later in reports).
+- **`deleteIngredientAction`** only becomes practically useful after Phase C ships; in Phase B alone there's nothing to reference an ingredient, so the recipe-items check is a no-op until then. The check is written defensively from day one to avoid retrofitting.
+- **`aiAutofillNutritionAction`** is the suggestion-only call; nothing is persisted until the admin confirms via `<AiSuggestionDialog>`. See [§7](#7-ai-nutrition-autofill).
+
+#### Allergen autofill helper (`lib/allergen-defaults.ts`)
+
+Tiny utility that suggests allergens based on ingredient name keywords:
+
+```typescript
+const RULES: Array<{ pattern: RegExp; codes: AllergenCode[] }> = [
+  { pattern: /múk[au]|chleb|otrub|pšenic|raž/i, codes: ["gluten"] },
+  { pattern: /mlieko|smotan|maslo|jogurt|syr|tvaroh|cmar|mascarpone/i, codes: ["milk"] },
+  { pattern: /vajc/i, codes: ["eggs"] },
+  { pattern: /mandl[ae]|orech|lieskov|kešu|piniov|para/i, codes: ["tree_nuts"] },
+  { pattern: /araši/i, codes: ["peanuts"] },
+  { pattern: /sezam/i, codes: ["sesame"] },
+  { pattern: /sója|sójov/i, codes: ["soybeans"] },
+  { pattern: /horčic/i, codes: ["mustard"] },
+  { pattern: /zeler/i, codes: ["celery"] },
+  // ...
+];
+
+export function suggestAllergens(name: string): AllergenCode[];
+```
+
+Wired to the ingredient form: when admin types a name, after debounce, allergen chips light up as suggestions ("Navrhnuté: Lepok"). Admin confirms with a click. Reduces typing for the seed-list and for new entries.
+
+This is a 30-LOC utility, not a magic system. It's cosmetic; the admin can override.
+
+---
+
+### 4a. Price input component
+
+**File:** `src/features/ingredients/components/price-input.tsx`
+
+`"use client"` controlled component. Admin types whatever number the supplier invoice shows; component normalizes to cents/kg (mass) or cents/piece (piece) on each keystroke.
+
+```typescript
+type Props = {
+  baseUnit: "g" | "piece";
+  valueCents: number | null;          // canonical (cents/kg or cents/piece)
+  onChange: (cents: number | null) => void;
+};
+```
+
+Render:
+
+```
+Cena                  [4.00]  €  za  [▼ 1 kg          ]
+                                       ├ 1 kg          (mass-based only)
+                                       ├ 500 g         (mass-based only)
+                                       ├ 100 g         (mass-based only)
+                                       ├ 1 kus         (piece-based only)
+                                       └ 12 kusov      (piece-based only)
+
+Uložené ako: 400 c/kg
+```
+
+Conversion via `lib/price-conversion.ts`:
+
+```typescript
+// admin sees "4.00 € za 1 kg"
+// stored = Math.round(400 * (1000 / 1000)) = 400 cents/kg
+
+// admin sees "4.99 € za 500 g"
+// stored = Math.round(499 * (1000 / 500)) = 998 cents/kg
+
+// admin sees "2.40 € za 12 kusov"
+// stored = Math.round(240 / 12) = 20 cents/piece
+```
+
+The dropdown's unit options switch based on `baseUnit` so the admin can never pick a mass unit for a piece-based ingredient. The "Uložené ako" hint shows the normalized integer live as the admin types so input errors are caught immediately.
+
+When `valueCents` is null (placeholder / "Cena: doplniť"), the input shows empty + a red helper "Cena nie je zadaná".
+
+### 4b. Duplicate detection at create time
+
+**File:** `src/features/ingredients/components/duplicate-suggestion.tsx`
+
+`"use client"` controlled component, rendered under the name field on the create form (not the edit form).
+
+Behavior:
+- Debounce 300 ms after admin stops typing
+- Call `findSimilarIngredients(name)` via a server action wrapper
+- If results: render a row of clickable suggestion chips: "Možno máte na mysli: **Hladká múka T650** · **Polohrubá múka** · ... — klik pre vybranie"
+- Click → close the create dialog and navigate to the existing ingredient's edit page
+- If admin proceeds anyway (clicks Save), the create runs. No hard block.
+
+This is the cheapest, highest-impact duplicate-prevention feature. ~50 LOC of UI + 1 query.
+
+### 4c. Duplicates review tool
+
+**Route:** `/admin/ingredients/duplicates`
+
+`src/app/(admin)/admin/ingredients/duplicates/page.tsx`
+
+Server component, `requireIngredientEdit()`. Lists pairs of ingredients above a similarity threshold (default 0.7) with:
+- Both names + IDs
+- Similarity score
+- Created-at deltas
+- Click-through to edit each side
+- No automated merge (would require recipe-item retargeting; do that by hand)
+
+Pure diagnostic. Linked from the ingredients list page header: `[Duplicity (3)]` badge when any pairs exist.
+
+### 5. Routes
+
+#### `/admin/ingredients` — list page
+
+`src/app/(admin)/admin/ingredients/page.tsx`
+
+Server component. `requireStaff()` guard at the top.
+
+Layout:
+- Header: title, `[+ Nová surovina]` button (calls `createIngredientAction` then redirects)
+- Filter row: search input (name), `isActive` toggle, "Bez ceny" filter (price = 0)
+- Table: name, baseUnit chip (g / ks), price per unit, allergens chips, active state, updatedAt, actions menu
+- Pagination: server-side, 50 per page (cursor or offset — match existing patterns)
+
+Reuses the `ColumnHeader` / `DataTable` patterns from existing admin tables (e.g. orders, products).
+
+#### `/admin/ingredients/[id]` — detail / edit page
+
+`src/app/(admin)/admin/ingredients/[id]/page.tsx`
+
+Server component, loads ingredient + price history in parallel, `requireStaff()`, 404 if missing.
+
+Renders:
+- `<IngredientForm>` (the same component used in Phase C's inline Sheet)
+- `<PriceHistoryPanel>` — last 20 price changes as a list with mini sparkline (the `tremor` or shadcn chart primitive — pick one or roll a tiny SVG; sparkline is nice-to-have, list is required)
+- `[Vymazať surovinu]` button with confirm dialog → `deleteIngredientAction`. If it returns the "used in N recipes" error, dialog stays open and shows the offending recipe list with links.
+
+#### Admin nav
+
+`src/app/(admin)/admin/_components/sidebar.tsx` — add "Suroviny" entry.
+
+---
+
+### 6. Ingredient form component
+
+**File:** `src/features/ingredients/components/ingredient-form.tsx`
+
+`"use client"`, RHF + Zod resolver. **Designed to work in two contexts:**
+
+1. **Standalone page** (`/admin/ingredients/[id]`): full-width layout, save button at the bottom, also exposes Delete + Active toggle
+2. **Sheet from Phase C recipe builder**: compact layout, save closes sheet, no delete button, ingredient is created in `isActive: true` state
+
+Public API:
+
+```typescript
+type Props = {
+  initial?: IngredientWithRelations;        // undefined = create mode
+  allergens: Allergen[];                     // from getAllergens()
+  variant?: "page" | "sheet";                // layout switch
+  onSaved?: (ingredient: Ingredient) => void;  // sheet uses this to feed picker
+};
+```
+
+Sections in render order:
+1. **Základné údaje** — name, slug (auto from name, editable), supplierName, notes
+2. **Jednotka a cena** — baseUnit radio (`g` / `kus`), gramsPerPiece (shown only when baseUnit=piece), `<PriceInput>` (admin-unit-aware, normalizes to `pricePerKgCents` or `pricePerPieceCents` on save — see §4a)
+3. **Alergény** — `<AllergenPicker>` from Phase A, with `<SuggestedAllergens>` chip row above it (driven by `suggestAllergens(name)`)
+4. **Nutričné hodnoty (na 100 g)** — `<NutritionFields>` with the 8 fields, plus `nutritionSource` badge (read-only) and a `[Vyplniť pomocou AI]` button (disabled with tooltip "Pripravované" — the action stub is created here for Phase D-or-later)
+
+Validation messages in Slovak. Save handler calls `createIngredientAction` or `updateIngredientAction` depending on mode.
+
+Slug field reuses the existing slug auto-generation pattern from products / categories (`draftSlug`, edit-on-blur, uniqueness check on action side).
+
+---
+
+### 7. AI nutrition autofill
+
+Originally scheduled for Phase D; moved here because nutrition data entry is the largest blocker on Phase C usefulness, and an admin-confirmed AI flow collapses it from "hours of typing across 50 ingredients" to "50 click-and-confirm cycles".
+
+#### New dependency
+
+```
+pnpm add @anthropic-ai/sdk
+```
+
+#### Singleton client
+
+**File:** `src/features/ingredients/lib/anthropic.ts`
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+export const anthropic = process.env.ANTHROPIC_API_KEY
+  ? new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+  : null;
+
+export const NUTRITION_SYSTEM_PROMPT = `Si nutričný odborník pre slovenskú pekáreň. Pre danú surovinu vráť presné nutričné hodnoty na 100 g vo formáte JSON.
+
+Hodnoty musia byť v základnej forme (suchá múka, surové vajce, atď.).
+Použi oficiálne zdroje: USDA FoodData Central, slovenské tabuľky zloženia potravín.
+Ak si nie si istý hodnotou, vráť 0 a "confidence": "low".
+
+Vráť výhradne JSON v presnom formáte:
+{ "kcal": number, "protein": number, "fat": number, "saturatedFat": number, "carbs": number, "sugar": number, "salt": number, "fiber": number, "confidence": "high" | "medium" | "low", "source": string }`;
+```
+
+The system prompt is wrapped in a `cache_control: { type: "ephemeral" }` block when sent so subsequent calls reuse the cached tokens. ~600 input tokens per call; cache hits drop that to negligible.
+
+#### Action
+
+`aiAutofillNutritionAction({ ingredientId })`:
+1. `requireIngredientEdit()`
+2. Load ingredient (need name + supplierName for the prompt)
+3. If `anthropic === null` (no API key), return `{ success: false, error: "AI nie je nakonfigurované" }`
+4. Call `claude-sonnet-4-5` with `max_tokens: 512`, system prompt cached
+5. Parse response JSON via `aiNutritionSuggestionSchema`
+6. Return `{ success: true, suggestion }` — **no DB write**
+7. On any failure: log error, return `{ success: false, error: "AI volanie zlyhalo" }`
+
+Prompt body (user message):
+```
+Surovina: {ingredient.name}{supplierName ? ` (${supplierName})` : ''}
+Jednotka: {baseUnit === 'g' ? '100 g' : `1 kus = ${gramsPerPiece} g, hodnoty na 100 g`}
+```
+
+#### Confirmation dialog
+
+**File:** `src/features/ingredients/components/ai-suggestion-dialog.tsx`
+
+`<AlertDialog>` opened by the `[Vyplniť pomocou AI]` button on the form. Shows:
+- 8 nutrition values side-by-side: current value (if any) vs AI suggestion, color-coded for changes
+- Confidence chip (`high` / `medium` / `low`)
+- Source line ("Podľa: USDA FoodData Central")
+- `[Použiť hodnoty]` / `[Zrušiť]`
+
+`[Použiť hodnoty]` applies the suggestion via `updateIngredientAction` with `nutritionSource: 'ai'`. Cancel just closes.
+
+#### Cost & rate limits
+
+Per call: ~600 input + ~200 output tokens. With prompt caching the system block is reused. Roughly fractions of a cent per ingredient. The full 50-ingredient catalog: well under €1 one-time. No rate limiting needed.
+
+#### Failure modes
+
+- **API key missing:** button disabled, tooltip "AI funkcia nie je nakonfigurované".
+- **API call fails (network, quota, etc.):** toast with Slovak error, no DB write, log the error.
+- **API returns malformed JSON:** Zod parse fails, error toast, no DB write.
+- **Low confidence:** dialog still opens, admin decides.
+
+---
+
+### 8. Logging
+
+`src/lib/logger.ts` — the `ingredients` namespace was added in pre-A scaffolding. Phase B uses it for:
+- `log.ingredients.error()` — failed actions, AI errors
+- `log.ingredients.warn()` — price-history append failures
+- `log.ingredients.info()` — AI autofill success/usage tracking
+
+---
+
+### 9. Documentation updates
+
+- `docs/database-schema.md` — document `ingredients` and `ingredient_price_history` tables
+- `docs/features-catalog.json` — new `ingredients` feature entry, update `lastUpdated`
+- `CLAUDE.md` (project) — mention ingredient catalog under Architecture / Feature Modules. One-line addition.
+
+---
+
+## File summary
+
+| Action | File |
+|---|---|
+| Edit | `src/db/schema.ts` — `ingredients`, `ingredient_price_history`, relations (**human approval**) |
+| Generate | `drizzle/NNNN_ingredients.sql` migration — includes `CREATE EXTENSION pg_trgm`, `CREATE EXTENSION unaccent`, trigram GIN index, seed `INSERT`s |
+| Create | `drizzle/seed/ingredients.ts` — bakery ingredient seed source (TS, used to author the SQL block) |
+| Create | `src/features/ingredients/schema.ts` |
+| Create | `src/features/ingredients/api/queries.ts` |
+| Create | `src/features/ingredients/api/actions.ts` |
+| Create | `src/features/ingredients/lib/allergen-defaults.ts` |
+| Create | `src/features/ingredients/lib/format.ts` — `formatBaseUnit`, `formatPricePerUnit` (shows "4,00 €/kg (0,40 €/100g)"), `formatPrice100g` |
+| Create | `src/features/ingredients/lib/price-conversion.ts` — admin-input unit → canonical cents/kg / cents/piece |
+| Create | `src/features/ingredients/lib/anthropic.ts` — singleton SDK client + system prompt |
+| Create | `src/features/ingredients/components/ingredient-form.tsx` |
+| Create | `src/features/ingredients/components/ingredients-table.tsx` |
+| Create | `src/features/ingredients/components/ingredient-list-filters.tsx` |
+| Create | `src/features/ingredients/components/nutrition-fields.tsx` |
+| Create | `src/features/ingredients/components/price-input.tsx` |
+| Create | `src/features/ingredients/components/price-history-panel.tsx` |
+| Create | `src/features/ingredients/components/ingredient-status-badge.tsx` |
+| Create | `src/features/ingredients/components/ai-suggestion-dialog.tsx` |
+| Create | `src/features/ingredients/components/duplicate-suggestion.tsx` |
+| Create | `src/features/ingredients/components/duplicates-table.tsx` |
+| Create | `src/app/(admin)/admin/ingredients/page.tsx` |
+| Create | `src/app/(admin)/admin/ingredients/[id]/page.tsx` |
+| Create | `src/app/(admin)/admin/ingredients/duplicates/page.tsx` |
+| Edit | `src/app/(admin)/admin/_components/sidebar.tsx` — "Suroviny" nav entry |
+| Edit | `.env.example` — add `ANTHROPIC_API_KEY` |
+| Edit | `docs/database-schema.md` — document new tables + extensions |
+| Edit | `docs/features-catalog.json` — add `ingredients` feature, update `lastUpdated` |
+| Edit | `CLAUDE.md` — one-line addition to feature module list |
+| Add dep | `@anthropic-ai/sdk` |
+
+---
+
+## Constraints (from `CLAUDE.md`)
+
+- **No `db.transaction()`** — sequential writes. Price-history append goes BEFORE the ingredient update so an audit-log gap is the worst-case failure (not a silent price change).
+- **No barrel files** — direct imports.
+- **No dynamic imports of internal modules.** Anthropic SDK is third-party, static import is fine.
+- **Slovak language** for user-facing text; code in English.
+- **`requireIngredientEdit()`** on every action and admin page (admin + manager). Resource-scoped guard from pre-A scaffolding.
+- **Schema changes require human approval** before editing `src/db/schema.ts`.
+- **No `pnpm db:push`** — generate + migrate.
+- **Prices in cents** (integer) throughout. See [arc overview §3](./_arc-overview.md#3-pricing-model-canonical) for the canonical model. `formatPricePerUnit()` only at render boundary.
+- **Structured logging** via `log.ingredients.error()` / `log.ingredients.warn()`.
+- **`cacheLife("hours")` + `cacheTag()`** on all queries; `revalidateTag()` after mutations. See [arc overview §5](./_arc-overview.md#5-cache-tag-matrix).
+- **Anthropic SDK uses prompt caching** on the system prompt (per `claude-api` skill convention).
+
+---
+
+## Open questions / design notes
+
+1. **Soft-delete vs hard-delete.** Going with hard-delete blocked by recipe-item references. Alternative: always soft-delete (set `isActive=false`, keep row forever). Hard-delete is cleaner but may cause grief if an ingredient gets accidentally removed and then needs to come back with the same id. Mitigation: the deletion UI requires typing the ingredient name to confirm. Soft-delete is also available via the `isActive` toggle; admins should reach for that 95% of the time.
+
+2. **Price history granularity.** Currently appends a row only when the price (`pricePerKgCents` or `pricePerPieceCents`) changes. Could also append on supplier change. Skipping that — supplier name is loosely-coupled metadata, history table tracks cost only. If supplier-attribution becomes important, add later.
+
+3. **Currency.** EUR only, hardcoded. No multi-currency. Slovak bakery, no plans to expand. If we ever do, that's a project-wide change, not an ingredient concern.
+
+4. **AI nutrition autofill button.** Wired to a stub action `aiAutofillNutritionAction` that returns `{ success: false, error: "Pripravované" }`. Phase D-or-later replaces the body with a Claude/Gemini call. Stub is shown disabled with tooltip; presence sets the hook for the future feature without blocking Phase B.
+
+5. **Bulk import / CSV.** Out of scope. Manual entry for the 50 seed ingredients + admin entry for new ones is enough at the team's scale. Revisit if catalog grows past ~500.
+
+6. **Density (`gramsPerMl`) field.** Confirmed dropped — base unit is `g` or `piece`, never `ml`. If admin imports a recipe written in ml, they convert at entry time (200 ml mlieka → 200 g, water density). Documented in admin help text on the form.
+
+7. **Multi-language ingredient names.** Slovak only, single `name` column. Matches existing convention (products, categories all use a single Slovak name).
+
+---
+
+## Acceptance criteria
+
+- [ ] Schema migration runs cleanly; pg_trgm and unaccent extensions installed; trigram GIN index present
+- [ ] Seed produces 50 ingredients with placeholder prices and NULL nutrition
+- [ ] Each seed ingredient has a corresponding `ingredient_price_history` row with `source = 'seed'`
+- [ ] Admin can create, edit, fuzzy-search ("muka" finds "Hladká múka T650"), and soft-deactivate ingredients
+- [ ] Selecting `baseUnit = piece` reveals and requires the `gramsPerPiece` field; pricing input switches to piece-based units
+- [ ] `<PriceInput>` normalization preview ("Uložené ako: 400 c/kg") updates as admin types and changes unit dropdown
+- [ ] CHECK constraint blocks saving an ingredient with both `pricePerKgCents` and `pricePerPieceCents` set
+- [ ] Updating the price inserts a `ingredient_price_history` row BEFORE updating the ingredient; price chart reflects the change
+- [ ] Ingredient list filter "Bez ceny" surfaces all rows with `pricePerKgCents = 0` (or `pricePerPieceCents = 0`)
+- [ ] Suggested allergens chip row lights up based on the ingredient name
+- [ ] Duplicate suggestion appears under the name field at create time when similarity > 0.6
+- [ ] `/admin/ingredients/duplicates` lists pairs above the threshold
+- [ ] `<IngredientForm>` works correctly in both `variant="page"` and `variant="sheet"` (unit test the form contract)
+- [ ] `[Vyplniť pomocou AI]` button opens dialog with a suggestion + confidence + source; admin confirms persists with `nutritionSource = 'ai'`
+- [ ] AI button disabled with tooltip when `ANTHROPIC_API_KEY` is missing
+- [ ] Failed AI call surfaces a Slovak error toast and writes no data
+- [ ] All actions guarded by `requireIngredientEdit()`; non-staff get 403
+- [ ] Hard-delete blocked when (future) recipe items reference the ingredient (no-op until Phase C; defensive code present)
+- [ ] No barrel files; no dynamic imports of internal modules
+- [ ] All queries cached with `cacheLife("hours")` and tags; mutations invalidate per the [tag matrix](./_arc-overview.md#5-cache-tag-matrix)
+
+---
+
+## Out of scope (Phase D / E / future)
+
+- Phase D: nutrition computation in recipe resolver, PDP nutrition table (AI autofill body moved into Phase B above)
+- Phase E: ERP cost reports using `ingredient_price_history`
+- Multi-supplier price comparison
+- Inventory tracking (stock, expiry, reorder)
+- Bulk CSV import / supplier feed integration
+- Vector embeddings for ingredient semantic search (pg_trgm covers it; vectors live in [arc overview §9](./_arc-overview.md#9-fuzzy-search--duplicate-detection) as a future option for recipe similarity only)
+- Automated duplicate merge (the cleanup tool is review-only)
+- Public-facing display of any ingredient data

--- a/docs/specs/nutrition-pdp-phase-d.md
+++ b/docs/specs/nutrition-pdp-phase-d.md
@@ -1,0 +1,444 @@
+# Nutrition Derivation & PDP Display (Phase D) — Implementation Spec
+
+> **Read first:** [`_arc-overview.md`](./_arc-overview.md). The AI nutrition autofill originally scheduled for this phase **moved into Phase B** — by the time Phase D ships, ingredients already have nutrition data populated. Phase D's scope is therefore smaller than originally drafted.
+
+## Overview
+
+Compute nutrition values per 100 g of finished product from the recipe (extending the Phase C resolver), surface allergens + nutrition on the public product detail page, switch the PDP allergen source from the manual Phase A column to ingredient-driven derivation (for products with a recipe), and ship the drift report. After this phase the customer-facing product page is fully informed by the recipe graph; the manual `allergenCodes` column on products stays as fallback for products without a recipe.
+
+## Goals
+
+- Recipe resolver produces nutrition per 100 g of finished product alongside cost (single pass, single source of truth).
+- PDP renders a standard EU-format nutrition table (Energia / Tuky / Sacharidy / ... / Soľ) for every product with a recipe.
+- PDP allergen list switches data source from `products.allergenCodes` (manual) to derived from recipe ingredients for products with a recipe.
+- Products **without** a recipe keep using the manual `allergenCodes` column — fallback path.
+- Admin can override computed nutrition per product when the computed value is wrong (suppliers' missing data, unusual loss profiles).
+- JSON-LD on PDP gains `nutritionInformation`.
+- Drift report identifies products where manual `allergenCodes` and derived list disagree.
+
+**Not in this phase anymore (moved to Phase B):** AI nutrition autofill body + dialog. Ingredients already have nutrition data when Phase D ships.
+
+## Non-goals
+
+- Per-ingredient yield loss (recipe-level `yieldLossPercent` from Phase C is enough).
+- Any change to the recipe builder's UX beyond the new "Nutričné hodnoty" tile in the live preview panel.
+- Allergen filtering on the e-shop listing page (deferred — easy add later from `getDerivedAllergens()`).
+- B2B-format printable EU labels (downloadable PDF). Out of scope; revisit in a future phase.
+- Bulk AI nutrition fill (one ingredient at a time only).
+- Storing AI-generated draft revisions for review queues. Direct write with admin confirmation.
+
+---
+
+## Prerequisites
+
+- Phase A — `allergens` reference table + `products.allergenCodes` + tab structure (`Info | Recenzie`).
+- Phase B — `ingredients` table with `nutritionPer100` jsonb + `nutritionSource` enum + `gramsPerPiece` + the AI autofill flow already shipped (so ingredients are populated by the time Phase D runs).
+- Phase C — `recipes`, `recipe_items`, `products.recipeId`, `cost-resolver.ts`, `getResolverContext()`, the **Recept** tab on the product page.
+
+If any of A/B/C have not shipped, Phase D cannot start.
+
+---
+
+## What to build
+
+### 1. Schema changes (`src/db/schema.ts`) — REQUIRES HUMAN APPROVAL
+
+Two small additions; nothing dropped (the deprecation of `products.allergenCodes` is a future cleanup, not a Phase D step — see [Allergen source migration](#3-allergen-source-migration)).
+
+#### `products.nutritionOverride` (new column)
+
+```typescript
+nutritionOverride: jsonb("nutrition_override").$type<NutritionPer100>(),
+```
+
+Nullable. When non-null, PDP and admin display it verbatim and skip computation. Same shape as `ingredients.nutritionPer100` (defined in Phase B).
+
+#### `ingredients.nutritionSource` enum extension
+
+Phase B's enum was `["manual", "ai", "supplier", "seed"]`. No change here — Phase B already added `'ai'` for forward compatibility. The AI autofill action sets it to `'ai'` after saving.
+
+#### Migration
+
+`pnpm db:generate` produces a one-line ALTER TABLE for `products`. No backfill — the column starts NULL across the board.
+
+---
+
+### 2. Resolver extension (`src/features/recipes/lib/cost-resolver.ts`)
+
+Extend the Phase C resolver to compute nutrition in the same recursive pass. Cost and nutrition share the recursion, the visited-set, the cycle/depth checks — walking it twice would be wasteful and risk drift.
+
+#### Extended return shape
+
+```typescript
+export type ResolvedRecipe = {
+  // existing (Phase C)
+  batchCostCents: number;
+  costPerUnitCents: number;
+  allergenCodes: AllergenCode[];
+  finishedMassGrams: number;
+  trace: ResolvedRecipeItem[];
+
+  // new (Phase D)
+  batchNutrition: NutritionPer100;     // sum across batch, in absolute grams/kcal
+  nutritionPer100: NutritionPer100;    // per 100 g of finished product
+};
+```
+
+`ResolvedRecipeItem` gets a `contributedNutrition: NutritionPer100` field for the live preview to show ingredient-level breakdown if needed (defer rendering this; data is there for free).
+
+#### Algorithm additions
+
+For each item walked:
+
+```typescript
+// inside the items loop in resolveRecipeCost():
+let itemNutrition: NutritionPer100;
+let itemMassGrams: number;
+
+if (item.ingredientId) {
+  const ing = ctx.ingredients.get(item.ingredientId)!;
+  itemMassGrams = ing.baseUnit === "g"
+    ? item.quantityBaseUnit
+    : item.quantityBaseUnit * (ing.gramsPerPiece ?? 0);
+  if (ing.nutritionPer100 && itemMassGrams > 0) {
+    itemNutrition = scaleNutrition(ing.nutritionPer100, itemMassGrams / 100);
+  } else {
+    itemNutrition = ZERO_NUTRITION;
+  }
+} else if (item.subRecipeId) {
+  const sub = resolveRecipeCost(item.subRecipeId, ctx, new Set(visited));
+  // sub-recipe is consumed by mass; quantity is in grams of the sub-recipe
+  itemMassGrams = item.quantityBaseUnit;
+  const fraction = sub.finishedMassGrams > 0
+    ? itemMassGrams / sub.finishedMassGrams
+    : 0;
+  itemNutrition = scaleNutrition(sub.batchNutrition, fraction);
+}
+
+// accumulate into recipe totals
+batchNutrition = sumNutrition(batchNutrition, itemNutrition);
+```
+
+After the loop:
+
+```typescript
+const nutritionPer100 = finishedMassGrams > 0
+  ? scaleNutrition(batchNutrition, 100 / finishedMassGrams)
+  : ZERO_NUTRITION;
+```
+
+`scaleNutrition(n, factor)` and `sumNutrition(a, b)` are pure helpers (8-line each, in the same file or a sibling `nutrition-math.ts`).
+
+#### Edge cases
+
+- **Ingredient without nutrition data** (`nutritionPer100 IS NULL`): contributes zero. Resolver does not throw. Live preview surfaces a chip: "N suroviny bez nutričných hodnôt" so the admin knows the result is incomplete.
+- **`gramsPerPiece` missing on a piece-based ingredient** (Phase B's CHECK should prevent this; defensive zero-mass fallback): contributes zero, log warn.
+- **`finishedMassGrams = 0`** (admin hasn't entered batch yield): `nutritionPer100` is the zero blob, preview shows "Zadajte hmotnosť šarže".
+
+These cases must not break the resolver. The error states already established for cycle / depth / missing recipe stay the only fatal paths.
+
+---
+
+### 3. Allergen source migration
+
+The substantive customer-facing change. PDP today reads `products.allergenCodes` (Phase A); Phase D switches to derived.
+
+#### New query: `getDerivedProductDisplay(productId)`
+
+`src/features/products/api/queries.ts` — single function that returns the display data PDP needs:
+
+```typescript
+type ProductDisplay = {
+  product: Product;
+  allergens: Allergen[];                 // resolved Allergen rows (with nameSk)
+  nutrition: NutritionPer100 | null;     // null when no recipe AND no override
+  nutritionPresent: boolean;
+  costSource: "computed" | "override" | "none";  // for admin debugging only
+};
+
+export async function getDerivedProductDisplay(productId: string): Promise<ProductDisplay>;
+```
+
+Resolution rules:
+
+| Allergens source | Triggered when |
+|---|---|
+| Derived (recipe → ingredients) | Product has `recipeId` and recipe resolves successfully |
+| Manual fallback (`products.allergenCodes`) | Product has no `recipeId`, OR resolver throws |
+
+| Nutrition source | Triggered when |
+|---|---|
+| Override (`products.nutritionOverride`) | Column is non-null |
+| Computed (resolver) | Recipe exists and resolves successfully |
+| None | Neither |
+
+Caching: `cacheLife("hours")`, tags `products`, `product-${id}`, `recipes` (so any recipe edit invalidates dependent products). Resolver context is fetched once per call via `getResolverContext()` (Phase C).
+
+#### Updated PDP fetch
+
+`src/app/(public)/(pages)/product/[slug]/page.tsx` calls `getDerivedProductDisplay(result.id)` in parallel with the existing slug query, then passes both to render.
+
+#### Phase A column status
+
+`products.allergenCodes` is **not** dropped in Phase D. It stays as the manual fallback for products without a recipe. The admin product form continues to show the Phase A allergen picker, but its label/help text changes:
+
+> "Tieto alergény sa použijú len pre produkty bez priradeného receptu. Pri produkte s receptom sa alergény vypočítajú zo surovín."
+
+When a recipe is linked the picker becomes read-only with a banner showing the derived list and a link to the recipe.
+
+#### Drift detection (admin tool)
+
+A new admin page `/admin/recipes/drift` (or a section on `/admin/recipes`) that lists products where manual `allergenCodes` differs from derived allergens. Pure read-only diagnostic — no automated reconciliation. Admin can:
+- Click a row to open the product
+- See what changed
+- Decide to clear the manual column (since recipe wins anyway) or fix the recipe
+
+This is the safety net for the migration. It also runs as a one-time pass when Phase D ships, surfacing every product whose manual list disagrees with the (now-authoritative) recipe-derived list.
+
+---
+
+### 4. PDP rendering
+
+#### Allergens section
+
+The existing Phase A `<AllergenList>` component stays in place; only the data source changes (now reading from `getDerivedProductDisplay()`). Empty state behavior unchanged: returns `null` when no allergens.
+
+#### New: nutrition table
+
+**Component:** `src/features/nutrition/components/nutrition-table.tsx`
+
+Server component. Renders the EU-format nutrition table (Slovak labels):
+
+```
+Nutričné hodnoty na 100 g
+
+Energia                 1192 kJ / 285 kcal
+Tuky                    3,2 g
+   z toho nasýtené      0,8 g
+Sacharidy               55 g
+   z toho cukry         3 g
+Vláknina                4 g
+Bielkoviny              9 g
+Soľ                     1,2 g
+```
+
+- Slovak number formatting (decimal comma, EU locale)
+- Two columns: label + value
+- Saturated fat and sugars are nested under their parents with em-space indent
+- Renders `null` when no nutrition data is available (no recipe AND no override)
+- Below the table, a small line: "Hodnoty sú vypočítané z receptu" or "Hodnoty zadané manuálne", subdued styling
+
+Energy calculation: kJ from kcal via the standard 4.184 multiplier.
+
+Returns `null` (not an empty card) when there's nothing to show — silence is the right default for products that don't have nutrition data yet.
+
+#### PDP integration
+
+`src/app/(public)/(pages)/product/[slug]/page.tsx` — add `<NutritionTable nutrition={display.nutrition} source={display.nutritionSource} />` below the existing allergen section.
+
+#### JSON-LD update
+
+The PDP already emits `Product` JSON-LD around line 150. Add `nutritionInformation` per [Schema.org/NutritionInformation](https://schema.org/NutritionInformation):
+
+```typescript
+nutritionInformation: nutrition ? {
+  "@type": "NutritionInformation",
+  servingSize: "100 g",
+  calories: `${nutrition.kcal} kcal`,
+  fatContent: `${nutrition.fat} g`,
+  saturatedFatContent: `${nutrition.saturatedFat} g`,
+  carbohydrateContent: `${nutrition.carbs} g`,
+  sugarContent: `${nutrition.sugar} g`,
+  proteinContent: `${nutrition.protein} g`,
+  fiberContent: `${nutrition.fiber} g`,
+  sodiumContent: `${nutrition.salt * 0.4} g`,   // salt → sodium conversion
+} : undefined,
+```
+
+---
+
+### 5. Admin: nutrition override
+
+#### Product form additions
+
+`src/app/(admin)/admin/products/[id]/_components/product-form.tsx` — Info tab gets a new collapsible section "Manuálne nutričné hodnoty" between Description and Allergens. Closed by default.
+
+When opened:
+- Toggle: "Použiť ručné nutričné hodnoty" (writes/clears `products.nutritionOverride`)
+- 8 numeric inputs (same as Phase B's `<NutritionFields>` — reuse the component)
+- Below: a read-only preview of the **computed** nutrition (when recipe exists) so admin can see what they'd be overriding
+
+The toggle behavior:
+- Off → `nutritionOverride = null`, computed value used
+- On → `nutritionOverride = { ... }`, manual value used. Defaulting on first toggle copies the currently-computed values so the admin starts from a sensible baseline.
+
+#### New schema field on `updateProductSchema`
+
+```typescript
+nutritionOverride: nutritionPer100Schema.nullable(),
+```
+
+Reused from Phase B's Zod schema.
+
+#### Recipe builder live preview gets a nutrition tile
+
+`src/features/recipes/components/live-preview-panel.tsx` — section already had a "Nutričné /100g" placeholder mention in Phase C; Phase D fills it in:
+
+```
+Nutričné /100g
+Energia       285 kcal
+Bielkoviny    9 g
+Tuky          3 g
+   nasýtené   0,8 g
+Sacharidy     55 g
+   cukry      3 g
+Vláknina      4 g
+Soľ           1,2 g
+```
+
+If any walked ingredient has `nutritionPer100 = null`, show a small chip: "N surovín bez nutričných hodnôt" with click-to-jump to the offending row.
+
+---
+
+### 6. AI nutrition autofill — moved to Phase B
+
+This section originally specced the body of `aiAutofillNutritionAction` + the confirmation dialog. The work shipped in Phase B instead (see [`ingredients-phase-b.md` §7](./ingredients-phase-b.md#7-ai-nutrition-autofill)) so admins could populate the ingredient catalog with real nutrition data **before** Phase C's recipe builder needed it.
+
+No work in Phase D on this surface. Move on.
+
+---
+
+### 7. Caching strategy
+
+Tag map for the new flows:
+
+| Mutation | Tags invalidated |
+|---|---|
+| Recipe header / item edit | `recipes`, `recipe-${id}`, `products` (PDP allergens + nutrition come from the resolver) |
+| Ingredient nutrition or price edit | `ingredients`, `ingredient-${id}`, `recipes` (because resolver context is cached as a whole graph) |
+| Product `nutritionOverride` change | `products`, `product-${id}` |
+| Product `recipeId` link/unlink | `products`, `product-${id}`, `recipes` |
+
+`getResolverContext()` (Phase C) tagged with both `ingredients` and `recipes` so either invalidates the whole graph. Acceptable: edits are rare relative to reads.
+
+---
+
+### 8. Drift report admin tool
+
+`src/app/(admin)/admin/recipes/drift/page.tsx` — read-only diagnostic. Paginated to stay performant as the product catalog grows.
+
+**Data source:** a dedicated cached query `getAllergenDrift({ offset, limit })` that walks products page-by-page rather than loading the entire catalog into memory:
+
+```typescript
+"use cache";
+export async function getAllergenDrift(opts: { offset?: number; limit?: number }) {
+  cacheLife("hours");
+  cacheTag("recipes", "products", "allergens-drift");
+  // Returns { items: DriftRow[], total: number }
+  // Each DriftRow: { productId, productName, manualCodes, derivedCodes, added, removed }
+  // Only rows where added.length + removed.length > 0 are returned
+}
+```
+
+The query uses `getResolverContext()` once and walks the requested page of products. Default page size 50, max 100. With 200 products this is one request; with 2000 it's 40 requests with cache reuse.
+
+Page renders:
+- Table of mismatches
+- Product name + link (to `/admin/products/[id]?tab=recept`)
+- Manual allergens (chips)
+- Derived allergens (chips)
+- Diff column: added (green) / removed (red)
+- Pager at the bottom
+- Empty state: green "Žiadne rozdiely" panel
+
+No edit actions on this page — admin clicks through to fix at the source.
+
+---
+
+## File summary
+
+| Action | File |
+|---|---|
+| Edit | `src/db/schema.ts` — `products.nutritionOverride` (**human approval**) |
+| Generate | `drizzle/NNNN_nutrition_override.sql` migration |
+| Edit | `src/features/recipes/lib/cost-resolver.ts` — extend to compute nutrition |
+| Create | `src/features/recipes/lib/nutrition-math.ts` — `scaleNutrition`, `sumNutrition`, `ZERO_NUTRITION` |
+| Edit | `src/features/recipes/lib/client-preview.ts` — surface nutrition in client preview |
+| Edit | `src/features/recipes/components/live-preview-panel.tsx` — render nutrition tile |
+| Create | `src/features/products/api/queries.ts` — add `getDerivedProductDisplay`, `getAllergenDrift` |
+| Edit | `src/features/products/schema.ts` — add `nutritionOverride` to `updateProductSchema` |
+| Edit | `src/features/products/api/actions.ts` — persist `nutritionOverride` in `updateProductAction` |
+| Create | `src/features/nutrition/components/nutrition-table.tsx` — public PDP component |
+| Create | `src/features/nutrition/lib/format-nutrition.ts` — Slovak number formatting |
+| Edit | `src/app/(public)/(pages)/product/[slug]/page.tsx` — fetch derived display + render `<NutritionTable>` + extend JSON-LD |
+| Edit | `src/app/(admin)/admin/products/[id]/_components/product-form.tsx` — nutrition override section in Info tab; allergen picker becomes read-only when recipe exists |
+| Create | `src/app/(admin)/admin/recipes/drift/page.tsx` — paginated drift report |
+| Edit | `docs/database-schema.md` — document new column |
+| Edit | `docs/features-catalog.json` — extend `products`, `recipes` entries; new `nutrition` feature; update `lastUpdated` |
+| Edit | `CLAUDE.md` — note that PDP allergens/nutrition derive from recipes |
+
+---
+
+## Constraints
+
+- **No `db.transaction()` / `db.batch()`** — no multi-row writes in Phase D anyway.
+- **No barrel files** — direct imports.
+- **No dynamic imports of internal modules.**
+- **Slovak language** for user-facing text.
+- **`requireProductEdit()`** for the new product override action; **public** queries (`getDerivedProductDisplay`) need no guard. `getAllergenDrift` runs behind `requireRecipeView()` on the page.
+- **Schema changes require human approval** before editing `src/db/schema.ts`.
+- **No `pnpm db:push`** — generate + migrate.
+- **Costs in cents**, **nutrition in grams / kcal** (kJ derived).
+- **Structured logging** via `log.nutrition.error()` (from pre-A scaffolding) and `log.products.warn()`.
+- **`cacheLife("hours")` + `cacheTag()`** on all queries; mutations invalidate per [arc overview §5](./_arc-overview.md#5-cache-tag-matrix).
+
+---
+
+## Performance notes
+
+- `getDerivedProductDisplay()` runs the resolver per product on cache miss. With ~200 products and `cacheLife("hours")`, the worst case is 200 resolver runs per hour. Each resolver run is sub-millisecond (in-memory walk). Negligible.
+- Nutrition computation reuses the resolver's existing recursion — no additional DB hits.
+- AI autofill is admin-triggered, one ingredient at a time. No background jobs.
+- JSON-LD payload grows by ~250 bytes per product page. Acceptable.
+
+---
+
+## Open questions / decisions to lock
+
+1. **Energy unit display: kcal only, or kJ + kcal?** EU labelling regulations (Reg. 1169/2011) require **both** kJ and kcal in that order. Spec defaults to "kJ / kcal" rendering. Lock in.
+2. **Salt vs sodium.** EU labels use salt; Schema.org/NutritionInformation uses `sodiumContent`. Conversion: salt × 0.4 ≈ sodium. Spec applies in JSON-LD only; admin UI and PDP show salt only.
+3. **Decimals shown on PDP.** Standard Slovak rounding: kcal to whole, grams to one decimal, energy in kJ to whole. Lock in unless you have a different convention.
+4. **AI model choice.** `claude-sonnet-4-5` is the default for Phase D. Could downgrade to Haiku for cost; nutrition-fact lookups don't need high reasoning. Recommend starting with Sonnet 4.5 (per `claude-api` skill conventions) and revisiting if cost bites. ~50 calls one-time, ~5 cents total either way.
+5. **Drift report frequency.** Phase D ships the page; suggest no automated digest email yet. Admin checks ad-hoc. If drift becomes common we add a weekly summary.
+6. **Should `products.allergenCodes` ever be dropped?** Recommended: keep it indefinitely. Real-world bakery has products without recipes (resold packaged items, simple drinks). The fallback is structurally cheap and removes no signal.
+
+---
+
+## Acceptance criteria
+
+- [ ] Schema migration adds `products.nutritionOverride`, no backfill needed
+- [ ] Resolver returns both `cost` and `nutrition` in one pass; cycle/depth/missing-data behavior unchanged
+- [ ] Resolver unit tests cover the new nutrition math paths (per [arc overview §11](./_arc-overview.md#11-testing-strategy))
+- [ ] PDP renders the EU-format nutrition table for any product with a recipe
+- [ ] PDP allergen list shows derived allergens when product has a recipe; falls back to manual when not
+- [ ] When `nutritionOverride` is set, PDP shows the override and labels it "Hodnoty zadané manuálne"
+- [ ] Recipe live preview shows nutrition per 100 g and warns about ingredients with missing nutrition data
+- [ ] JSON-LD on PDP includes `nutritionInformation` when available
+- [ ] Drift report is paginated (server-side), default 50 per page; empty state when in sync
+- [ ] All cache tags invalidate correctly per [arc overview §5](./_arc-overview.md#5-cache-tag-matrix): edit ingredient nutrition → product PDP nutrition updates after `revalidateTag` fires
+- [ ] Admin product form: allergen picker becomes read-only when a recipe is linked, with a banner pointing at the recipe
+- [ ] No barrel files; no dynamic imports of internal modules; the new admin action guarded by `requireProductEdit()`
+
+---
+
+## Out of scope (Phase E / future)
+
+- Phase E: store-level P&L queries built on `unitCostCents` (snapshotted in Phase C) + `ingredient_price_history` (Phase B)
+- Bulk AI autofill across the catalog
+- AI-suggested allergens (Phase B's regex helper is enough)
+- B2B-format printable nutrition labels (PDF download)
+- Allergen-based filtering on the e-shop listing page
+- Per-ingredient yield loss
+- Public-facing ingredient list ("Z čoho je vyrobené") on PDP
+- Cross-product nutrition comparison views
+- Customer reviews tied to nutrition values

--- a/docs/specs/recipes-phase-c.md
+++ b/docs/specs/recipes-phase-c.md
@@ -1,0 +1,793 @@
+# Recipes & Computed Cost (Phase C) — Implementation Spec
+
+> **Read first:** [`_arc-overview.md`](./_arc-overview.md) for the canonical pricing model, role guards, cache tags, and pre-A scaffolding (which already added `order_items.unitCostCents` and the product page tab structure).
+
+## Overview
+
+Add a recipe system on top of the ingredient catalog (delivered in Phase B). Each product can be linked to a recipe; recipes are made of ingredients and/or sub-recipes. The admin gets a spreadsheet-style recipe builder with live cost preview, recipe duplication for fast iteration, and an ingredient picker that supports both single-item selection and bulk-pull from another recipe.
+
+Production cost is written into the `order_items.unitCostCents` column (already added in Phase A scaffolding) so future ERP reports (Phase E) can compute store-level profitability.
+
+This phase delivers the **production cost** half of the recipe system. Nutrition derivation and PDP rendering land in Phase D. Allergens are derived from recipe ingredients here but the public PDP keeps reading the manual `allergenCodes` column from Phase A until Phase D switches the source.
+
+## Goals
+
+- Admin can build a recipe (final or sub-recipe) using ingredients and other sub-recipes.
+- Live cost preview updates as items are edited (cost per unit, batch cost, batch yield, derived allergens).
+- Each product can be linked to a final recipe; production cost is read-only on the product page.
+- Cost is snapshotted on `order_items.unitCostCents` at order creation so historical orders carry their cost-at-time-of-sale.
+- Sub-recipes are reusable; cycle detection and 3-level depth cap are enforced.
+- **Recipe duplication is a first-class MVP feature** — the "recipe 6 onward is mostly a variant of recipe N-1" workflow.
+- **Ingredient picker has a dual mode**: pick a single ingredient/sub-recipe, OR bulk-import all items from another recipe as the starting point.
+- **Picker pins recent + frequent items** so common ingredients are 1 click away after the first few recipes.
+
+## Non-goals
+
+- Nutrition computation and display on PDP — Phase D.
+- Switching public PDP allergens from manual (Phase A) to derived (Phase D).
+- Recipe versioning / history (cost snapshot on `order_items` covers the historical-correctness need).
+- Per-ingredient yield loss (recipe-level `yieldLossPercent` is enough for now).
+- Find-replace ingredient across recipes; bulk scale; recipe duplication. All future, see [Out of scope](#out-of-scope).
+- Public-facing changes. Admin-only phase.
+
+---
+
+## Prerequisites (must ship before this)
+
+Phase C assumes these are in place. Detailed in the linked specs / overview.
+
+```typescript
+// from Phase B (per arc-overview §3 pricing model)
+ingredients {
+  id: text PK             // 'ing_…'
+  name: text
+  slug: text unique
+  baseUnit: text          // 'g' | 'piece'
+  pricePerKgCents: integer | null     // when baseUnit = 'g' (XOR)
+  pricePerPieceCents: integer | null  // when baseUnit = 'piece' (XOR)
+  gramsPerPiece: integer? // required when baseUnit = 'piece'
+  allergenCodes: text[]   // FK semantics against allergens.code (Phase A)
+  nutritionPer100: jsonb  // populated by AI autofill in Phase B; Phase C does not read it
+  isActive: boolean
+  createdAt, updatedAt: timestamp
+}
+
+ingredient_price_history {
+  id, ingredientId, pricePerKgCents | null, pricePerPieceCents | null, effectiveFrom, supplier?, source
+}
+
+// from Phase A pre-A scaffolding (per arc-overview §2)
+order_items.unitCostCents: integer | null  // already present; Phase C is the first phase to write it
+
+// from Phase A pre-A scaffolding
+src/lib/auth/guards.ts:  requireRecipeView, requireRecipeEdit, requireCostView
+src/lib/logger.ts:       log.recipes namespace
+src/app/(admin)/admin/products/[id]/...:  Tabs structure (Info | Recenzie); Phase C adds Recept tab
+```
+
+If Phase B has not shipped, Phase C cannot start. The recipe builder needs a stocked ingredient catalog with real prices to be useful.
+
+---
+
+## What to build
+
+### 1. Schema changes (`src/db/schema.ts`) — REQUIRES HUMAN APPROVAL
+
+#### New table: `recipes`
+
+```typescript
+export const RECIPE_KINDS = ["product", "sub_recipe"] as const;
+export const RECIPE_STATUSES = ["draft", "published"] as const;
+
+export const recipes = pgTable(
+  "recipes",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createPrefixedId("rec")),
+    name: text("name").notNull().default("Nový recept"),
+    slug: text("slug")
+      .notNull()
+      .unique()
+      .$defaultFn(() => draftSlug("Nový recept")),
+    kind: text("kind")
+      .$type<(typeof RECIPE_KINDS)[number]>()
+      .notNull()
+      .default("product"),
+    status: text("status")
+      .$type<(typeof RECIPE_STATUSES)[number]>()
+      .notNull()
+      .default("draft"),
+    batchYieldUnits: integer("batch_yield_units").notNull().default(1),
+    batchYieldGrams: integer("batch_yield_grams").notNull().default(0),
+    yieldLossPercent: integer("yield_loss_percent").notNull().default(10),
+    notes: text("notes"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (t) => [
+    index("idx_recipes_kind_status").on(t.kind, t.status),
+    index("idx_recipes_slug").on(t.slug),
+    check("recipes_yield_units_positive", sql`${t.batchYieldUnits} > 0`),
+    check("recipes_yield_grams_non_negative", sql`${t.batchYieldGrams} >= 0`),
+    check(
+      "recipes_loss_percent_range",
+      sql`${t.yieldLossPercent} >= 0 AND ${t.yieldLossPercent} <= 50`
+    ),
+  ]
+);
+```
+
+#### New table: `recipe_items`
+
+The BOM. Each row is **either** an ingredient OR a sub-recipe — exactly one of the two FKs is non-null. Enforced by a CHECK constraint.
+
+```typescript
+export const recipeItems = pgTable(
+  "recipe_items",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createPrefixedId("rci")),
+    recipeId: text("recipe_id")
+      .notNull()
+      .references(() => recipes.id, { onDelete: "cascade" }),
+    ingredientId: text("ingredient_id").references(() => ingredients.id, {
+      onDelete: "restrict",
+    }),
+    subRecipeId: text("sub_recipe_id").references(() => recipes.id, {
+      onDelete: "restrict",
+    }),
+    quantityBaseUnit: integer("quantity_base_unit").notNull(),
+    sortOrder: integer("sort_order").notNull().default(0),
+    notes: text("notes"),
+  },
+  (t) => [
+    index("idx_recipe_items_recipe_id").on(t.recipeId, t.sortOrder),
+    index("idx_recipe_items_ingredient_id").on(t.ingredientId),
+    index("idx_recipe_items_sub_recipe_id").on(t.subRecipeId),
+    check(
+      "recipe_items_xor_ingredient_or_subrecipe",
+      sql`(${t.ingredientId} IS NOT NULL) <> (${t.subRecipeId} IS NOT NULL)`
+    ),
+    check("recipe_items_quantity_positive", sql`${t.quantityBaseUnit} > 0`),
+    check("recipe_items_no_self_reference", sql`${t.subRecipeId} <> ${t.recipeId}`),
+    // Direct cycle prevention only; multi-hop cycles checked in app layer.
+    unique("recipe_items_unique_ingredient").on(t.recipeId, t.ingredientId),
+    unique("recipe_items_unique_subrecipe").on(t.recipeId, t.subRecipeId),
+  ]
+);
+```
+
+The `unique` indexes prevent duplicate rows for the same ingredient/sub-recipe. They allow `NULL`s to coexist (PG default), so the XOR constraint above is the actual safety net.
+
+#### New columns on existing tables
+
+**`products.recipeId`** — nullable FK to `recipes`. A product without a recipe still works; cost panel shows "Recept nepriradený".
+
+```typescript
+recipeId: text("recipe_id").references(() => recipes.id, {
+  onDelete: "set null",
+}),
+```
+
+**`order_items.unitCostCents`** — **already added in Phase A scaffolding**, not part of Phase C's migration. Phase C is the first phase that writes a value into this column.
+
+#### Relations
+
+```typescript
+export const recipesRelations = relations(recipes, ({ many, one }) => ({
+  items: many(recipeItems),
+  product: one(products, {
+    fields: [recipes.id],
+    references: [products.recipeId],
+  }),
+}));
+
+export const recipeItemsRelations = relations(recipeItems, ({ one }) => ({
+  recipe: one(recipes, {
+    fields: [recipeItems.recipeId],
+    references: [recipes.id],
+  }),
+  ingredient: one(ingredients, {
+    fields: [recipeItems.ingredientId],
+    references: [ingredients.id],
+  }),
+  subRecipe: one(recipes, {
+    fields: [recipeItems.subRecipeId],
+    references: [recipes.id],
+  }),
+}));
+
+// Extend productsRelations
+recipe: one(recipes, {
+  fields: [products.recipeId],
+  references: [recipes.id],
+}),
+```
+
+#### Migration steps
+
+1. `pnpm db:generate` — produces three migration files (or one combined). Verify the XOR check is generated correctly; PG sometimes needs hand-tweaking for boolean-arithmetic CHECKs.
+2. `pnpm db:migrate`.
+3. No data backfill. `products.recipeId` and `order_items.unitCostCents` start NULL across the board. Existing orders are unaffected.
+
+---
+
+### 2. Cost resolver (pure function, importable from server + client)
+
+**File:** `src/features/recipes/lib/cost-resolver.ts`
+
+The single source of truth for cost / allergen computation. Pure, no DB access. Takes already-loaded data structures, returns computed numbers. Used by:
+
+- Server actions (authoritative compute on save and at order creation)
+- Client preview panel (instant feedback during edit)
+
+#### Input shape
+
+```typescript
+export type IngredientLite = {
+  id: string;
+  name: string;
+  baseUnit: "g" | "piece";
+  pricePerKgCents: number | null;     // when baseUnit = 'g'
+  pricePerPieceCents: number | null;  // when baseUnit = 'piece'
+  gramsPerPiece: number | null;
+  allergenCodes: AllergenCode[];
+};
+
+export type RecipeLite = {
+  id: string;
+  name: string;
+  batchYieldUnits: number;
+  batchYieldGrams: number;
+  yieldLossPercent: number;
+  items: RecipeItemLite[];
+};
+
+export type RecipeItemLite = {
+  ingredientId: string | null;
+  subRecipeId: string | null;
+  quantityBaseUnit: number;
+};
+
+export type ResolverContext = {
+  ingredients: Map<string, IngredientLite>;
+  recipes: Map<string, RecipeLite>;
+};
+
+export type ResolvedCost = {
+  batchCostCents: number;
+  costPerUnitCents: number;
+  allergenCodes: AllergenCode[];   // canonical-sorted, de-duped
+  finishedMassGrams: number;        // batchYieldGrams * (1 - lossPct/100)
+  trace: ResolvedCostItem[];        // one row per item, for the UI table
+};
+
+export type ResolvedCostItem = {
+  itemId: string;                  // matches recipe_items.id (when from server)
+  kind: "ingredient" | "sub_recipe";
+  refId: string;                    // ingredientId or subRecipeId
+  quantityBaseUnit: number;
+  unitCostCents: number;            // ingredient.pricePerBaseUnit OR computed sub-recipe per-unit cost
+  totalCostCents: number;           // unitCost * quantity
+  allergenCodes: AllergenCode[];
+};
+```
+
+#### Algorithm
+
+```typescript
+export function resolveRecipeCost(
+  recipeId: string,
+  ctx: ResolverContext,
+  visited: Set<string> = new Set()
+): ResolvedCost {
+  if (visited.has(recipeId)) {
+    throw new RecipeCycleError(recipeId, [...visited]);
+  }
+  if (visited.size >= MAX_RECIPE_DEPTH) {           // MAX_RECIPE_DEPTH = 3
+    throw new RecipeDepthError(recipeId, visited.size);
+  }
+  visited.add(recipeId);
+
+  const recipe = ctx.recipes.get(recipeId);
+  if (!recipe) throw new RecipeNotFoundError(recipeId);
+
+  let batchCostCents = 0;
+  const allergens = new Set<AllergenCode>();
+  const trace: ResolvedCostItem[] = [];
+
+  for (const item of recipe.items) {
+    if (item.ingredientId) {
+      const ing = ctx.ingredients.get(item.ingredientId);
+      if (!ing) throw new IngredientNotFoundError(item.ingredientId);
+
+      // Per arc-overview §3: storage is cents/kg (mass) or cents/piece (piece)
+      let total: number;
+      let perUnit: number;
+      if (ing.baseUnit === "g") {
+        if (ing.pricePerKgCents === null) { total = 0; perUnit = 0; }
+        else {
+          perUnit = ing.pricePerKgCents;
+          total = Math.round(item.quantityBaseUnit * ing.pricePerKgCents / 1000);
+        }
+      } else {
+        if (ing.pricePerPieceCents === null) { total = 0; perUnit = 0; }
+        else {
+          perUnit = ing.pricePerPieceCents;
+          total = item.quantityBaseUnit * ing.pricePerPieceCents;
+        }
+      }
+
+      batchCostCents += total;
+      for (const c of ing.allergenCodes) allergens.add(c);
+      trace.push({ kind: "ingredient", refId: ing.id, quantityBaseUnit: item.quantityBaseUnit,
+        unitCostCents: perUnit, totalCostCents: total,
+        allergenCodes: ing.allergenCodes, hasPrice: perUnit > 0 } as ResolvedCostItem);
+    } else if (item.subRecipeId) {
+      const sub = resolveRecipeCost(item.subRecipeId, ctx, new Set(visited));
+      const subPerGram = sub.batchCostCents / Math.max(sub.finishedMassGrams, 1);
+      const total = Math.round(subPerGram * item.quantityBaseUnit);
+      batchCostCents += total;
+      for (const c of sub.allergenCodes) allergens.add(c);
+      trace.push({ kind: "sub_recipe", refId: item.subRecipeId, quantityBaseUnit: item.quantityBaseUnit,
+        unitCostCents: Math.round(subPerGram), totalCostCents: total,
+        allergenCodes: sub.allergenCodes, hasPrice: subPerGram > 0 } as ResolvedCostItem);
+    }
+  }
+
+  const finishedMassGrams = Math.round(
+    recipe.batchYieldGrams * (1 - recipe.yieldLossPercent / 100)
+  );
+  const costPerUnitCents = Math.round(batchCostCents / Math.max(recipe.batchYieldUnits, 1));
+
+  return {
+    batchCostCents,
+    costPerUnitCents,
+    allergenCodes: [...allergens].sort((a, b) => ALLERGEN_ORDER[a] - ALLERGEN_ORDER[b]),
+    finishedMassGrams,
+    trace,
+  };
+}
+
+export class RecipeCycleError extends Error {}
+export class RecipeDepthError extends Error {}
+export class RecipeNotFoundError extends Error {}
+export class IngredientNotFoundError extends Error {}
+```
+
+Notes:
+- **Pricing model** is the canonical one from [arc overview §3](./_arc-overview.md#3-pricing-model-canonical): cents/kg for mass-based ingredients, cents/piece for piece-based. Resolver divides by 1000 for the mass case; piece case has no division.
+- **Zero-priced ingredients** (null `pricePerKgCents` / `pricePerPieceCents`, or admin-set 0) contribute zero. The `hasPrice` flag on each trace item lets the live preview surface "N surovín bez ceny" warnings to the admin.
+- Sub-recipe cost contribution is computed **per gram of finished sub-recipe** (`subBatchCost / subFinishedMass`), then multiplied by the quantity used. This is the correct model when a sub-recipe is consumed by mass (kvások, krém) — which is the bakery default.
+- All math in cents. Round once at the end of each recipe to avoid drift.
+- `visited` is cloned per branch (`new Set(visited)`) so siblings don't see each other's path.
+- Errors are typed so the action layer can map them to user-friendly Slovak messages.
+
+#### Cycle / depth pre-check helper
+
+`src/features/recipes/lib/can-add-sub-recipe.ts` — for the picker UI to filter invalid options at open time:
+
+```typescript
+export function canAddSubRecipe(
+  hostRecipeId: string,
+  candidateSubRecipeId: string,
+  recipesGraph: Map<string, string[]>   // recipeId -> sub-recipe IDs
+): { ok: true } | { ok: false; reason: "self" | "cycle" | "depth" };
+```
+
+Returns `{ ok: false, reason }` when adding the candidate would self-reference, create a cycle, or exceed depth 3. Keeps the picker filter logic out of components.
+
+---
+
+### 3. Feature module: `src/features/recipes/`
+
+```
+src/features/recipes/
+├── api/
+│   ├── queries.ts
+│   └── actions.ts
+├── components/
+│   ├── recipe-builder.tsx          # the page-level builder (used by both routes)
+│   ├── recipe-header-form.tsx      # name, kind, yields, loss
+│   ├── recipe-items-table.tsx      # sortable rows
+│   ├── recipe-item-row.tsx         # single editable row
+│   ├── ingredient-picker.tsx       # cmdk palette (ingredients + sub-recipes)
+│   ├── inline-ingredient-sheet.tsx # creates ingredient from picker
+│   ├── live-preview-panel.tsx      # cost / allergens
+│   ├── recipe-list-table.tsx       # /admin/recipes
+│   └── product-recipe-tab.tsx      # tab content on product page
+├── lib/
+│   ├── cost-resolver.ts
+│   ├── can-add-sub-recipe.ts
+│   └── client-preview.ts           # client-side wrapper around cost-resolver
+└── schema.ts
+```
+
+#### `schema.ts` — Zod
+
+```typescript
+import { z } from "zod";
+
+export const RECIPE_KINDS = ["product", "sub_recipe"] as const;
+export const RECIPE_STATUSES = ["draft", "published"] as const;
+
+export const recipeHeaderSchema = z.object({
+  name: z.string().trim().min(1, "Názov je povinný").max(100),
+  kind: z.enum(RECIPE_KINDS),
+  status: z.enum(RECIPE_STATUSES),
+  batchYieldUnits: z.number().int().positive("Výnos musí byť kladné číslo"),
+  batchYieldGrams: z.number().int().min(0),
+  yieldLossPercent: z.number().int().min(0).max(50),
+  notes: z.string().trim().max(2000).nullable(),
+});
+
+export const addRecipeItemSchema = z.object({
+  recipeId: z.string().min(1),
+  ingredientId: z.string().min(1).optional(),
+  subRecipeId: z.string().min(1).optional(),
+  quantityBaseUnit: z.number().int().positive(),
+}).refine(
+  (v) => Boolean(v.ingredientId) !== Boolean(v.subRecipeId),
+  { message: "Buď ingrediencia alebo subrecept, nie oboje" }
+);
+
+export const updateRecipeItemSchema = z.object({
+  itemId: z.string().min(1),
+  quantityBaseUnit: z.number().int().positive(),
+});
+
+export const removeRecipeItemSchema = z.object({
+  itemId: z.string().min(1),
+});
+
+export const reorderRecipeItemsSchema = z.object({
+  recipeId: z.string().min(1),
+  orderedItemIds: z.array(z.string().min(1)).min(1),
+});
+
+export const linkProductRecipeSchema = z.object({
+  productId: z.string().min(1),
+  recipeId: z.string().min(1).nullable(),   // null = unlink
+});
+
+export type RecipeHeaderSchema = z.infer<typeof recipeHeaderSchema>;
+export type AddRecipeItemSchema = z.infer<typeof addRecipeItemSchema>;
+export type UpdateRecipeItemSchema = z.infer<typeof updateRecipeItemSchema>;
+```
+
+#### `api/queries.ts`
+
+All queries use `"use cache"`, `cacheLife("hours")`, tagged for invalidation.
+
+```typescript
+"use cache";
+// getRecipes(opts?: { kind?: RecipeKind })  → list, tag "recipes"
+// getRecipeById(id)                          → recipe + items + nested ingredient/sub-recipe data, tag "recipes" + `recipe-${id}`
+// getRecipeByProductId(productId)            → resolver-ready data for a product's recipe (or null)
+// getResolverContext()                       → { ingredients: Map, recipes: Map } loaded as Maps for the resolver, tag "ingredients" + "recipes"
+// getRecipeDependents(recipeId)              → list of products + parent recipes referencing this recipe (for the "used by N products" footer)
+// getRecipeGraph()                           → Map<recipeId, subRecipeIds[]> for the picker's cycle/depth check, tag "recipes"
+```
+
+`getResolverContext()` is the workhorse: returns the full ingredient catalog + all published recipes as Maps, ready to feed `resolveRecipeCost()`. Cached aggressively (tag `recipes` + `ingredients`); invalidated on any recipe/ingredient mutation. Payload size is bounded — hundreds of rows max — so caching the whole graph is cheap.
+
+#### `api/actions.ts`
+
+All actions: `"use server"`, `await requireRecipeEdit()` (from pre-A scaffolding; admin + manager), error logged via `log.recipes.error()` (added in pre-A scaffolding), `revalidateTag()` after success.
+
+| Action | Input | Effect | Tags invalidated |
+|---|---|---|---|
+| `createRecipeAction` | `{ kind }` | Insert with defaults; if `kind=product` and called from product page, also link via `setProductRecipeAction`; redirect | `recipes` |
+| `updateRecipeHeaderAction` | `{ id, header }` | Validate + update; if `kind` switched to `sub_recipe`, unlink any product first | `recipes`, `recipe-${id}`, `products` |
+| `deleteRecipeAction` | `{ id }` | Block if it's a sub-recipe used by another recipe (check `getRecipeDependents`); delete cascades items | `recipes`, `recipe-${id}`, `products` |
+| `duplicateRecipeAction` | `{ id }` | Copy recipe + all items into a new `status=draft` recipe named `<name> (kópia)`; redirect to new id | `recipes` |
+| `addRecipeItemAction` | `AddRecipeItemSchema` | Insert; pre-check cycle/depth for sub-recipes via `canAddSubRecipe`; sortOrder = max+1 | `recipes`, `recipe-${recipeId}`, `products`, `reports` |
+| `bulkAddItemsFromRecipeAction` | `{ targetRecipeId, sourceRecipeId }` | Copy every item from `source` into `target` (sequential inserts, skip dups); respects cycle/depth for any sub-recipes | `recipes`, `recipe-${targetRecipeId}`, `products`, `reports` |
+| `updateRecipeItemAction` | `UpdateRecipeItemSchema` | Update quantity | `recipes`, `recipe-${recipeId}`, `products`, `reports` |
+| `removeRecipeItemAction` | `RemoveRecipeItemSchema` | Delete row | `recipes`, `recipe-${recipeId}`, `products`, `reports` |
+| `reorderRecipeItemsAction` | `ReorderRecipeItemsSchema` | Sequential UPDATEs (no transactions); idempotent | `recipes`, `recipe-${recipeId}` |
+| `linkProductRecipeAction` | `LinkProductRecipeSchema` | Set `products.recipeId` (or null); validate target recipe is `kind=product` | `products`, `product-${slug}`, `recipes` |
+| `publishRecipeAction` | `{ id }` | Validate via resolver (must succeed without errors), set `status=published` | `recipes`, `recipe-${id}`, `reports` |
+
+See [arc overview §5](./_arc-overview.md#5-cache-tag-matrix) for the full invalidation matrix.
+
+Every mutating action that affects cost/allergens of a product also invalidates `products` so PDP allergen list (Phase A) reflects ingredient changes when Phase D goes live without an extra invalidation pass.
+
+**Neon HTTP constraint:** `reorderRecipeItemsAction` is sequential UPDATEs (no `db.transaction()`). Order doesn't matter for correctness — partial failures leave a consistent state because each row's sortOrder is independent.
+
+---
+
+### 4. Routes
+
+#### `/admin/recipes` — sub-recipe list page
+
+`src/app/(admin)/admin/recipes/page.tsx`
+
+- Lists `kind=sub_recipe` rows only. Final recipes (`kind=product`) are reached through their parent product, not here.
+- Columns: name, items count, used-in count, status (draft/published), updated-at, actions
+- Header button: "+ Nový subrecept" → calls `createRecipeAction({ kind: "sub_recipe" })` → redirects to `/admin/recipes/[id]`
+- Server component, `requireRecipeView()` at the top (admin + manager; baker added in Phase 4 per [arc overview §4](./_arc-overview.md#4-role-matrix))
+
+Add to admin nav under a new "Recepty" section.
+
+#### `/admin/recipes/[id]` — sub-recipe builder
+
+`src/app/(admin)/admin/recipes/[id]/page.tsx`
+
+- Loads recipe + resolver context in parallel
+- Renders `<RecipeBuilder>` (the same component used by the product tab)
+- 404 if recipe doesn't exist or is `kind=product` (those are reached via product page)
+
+#### `/admin/products/[id]` — tabs added
+
+`src/app/(admin)/admin/products/[id]/page.tsx` and `_components/product-form.tsx`
+
+The product page tab structure already exists from Phase A scaffolding (`Info | Recenzie`). Phase C **adds the Recept tab** between them:
+
+```
+[ Info ] [ Recept ] [ Recenzie ]
+```
+
+(Phase A had 2 tabs; Phase C adds 1. Future ceny/obrazky splits, if ever needed, happen separately.)
+
+Tab strategy:
+- URL param `?tab=info|recept|recenzie`
+- Tabs primitive: [src/components/ui/tabs.tsx](src/components/ui/tabs.tsx)
+- Each tab's data is fetched only when active (server-side check on `searchParams.tab`). The Recept tab's resolver context is the heaviest payload, so this matters.
+- Recept tab visibility: server-side `requireRecipeView()` on the tab's data fetch and `requireRecipeEdit()` on every mutating action; client-side the tab trigger is hidden for non-staff (cosmetic, not security). When the baker role lands in Phase 4, only `requireRecipeView()` adds it — bakers see the tab but can't edit.
+
+The existing single-column form gets split across Info / Ceny / Obrázky tabs. Mostly a re-org, no logic changes. Reviews tab is a passthrough to existing review queries.
+
+#### Product Recept tab states
+
+Rendered by `<ProductRecipeTab>`:
+
+1. **No recipe linked**
+   - Empty state with two CTAs: `[Vytvoriť recept]` (creates new `kind=product` recipe and reloads tab) | `[Prepojiť existujúci]` (combobox of unlinked `kind=product` recipes)
+
+2. **Linked recipe**
+   - Renders `<RecipeBuilder>` inline, fully editable
+   - Header gets a strip: `[Otvoriť na samostatnej stránke ↗]` `[Odpojiť od produktu]`
+
+3. **Linked recipe missing or archived** (defensive)
+   - Warning chip + `[Odpojiť]`
+
+The "Otvoriť na samostatnej stránke" link points to `/admin/recipes/[id]` — same builder, different chrome. Useful when the admin wants to focus mode without product-page distractions.
+
+---
+
+### 5. Recipe builder component
+
+**File:** `src/features/recipes/components/recipe-builder.tsx`
+
+`"use client"` page-level component, hosts:
+- `<RecipeHeaderForm>` — RHF + Zod, explicit `[Uložiť]` button, calls `updateRecipeHeaderAction`
+- `<RecipeItemsTable>` — autosaving rows, dnd-kit reorder
+- `<LivePreviewPanel>` — sticky right-side card on desktop, collapsible drawer on mobile
+- `<IngredientPicker>` — `<Command>` palette opened by the items table
+
+#### Items table behavior (the hot path)
+
+- Each row: drag handle (dnd-kit `useSortable`), ingredient/sub-recipe cell, quantity input, unit badge (read-only, derived from ingredient.baseUnit), cost contribution (derived), % of batch (derived), remove button
+- Quantity input: debounced 500 ms autosave via `updateRecipeItemAction`. Debounced via a single ref-stored timer per row.
+- Optimistic UI via `useOptimistic`: typed quantity reflects in the row + preview panel before server confirms
+- Failed autosave: row goes red with retry button; preview reverts to last server state
+- Row remove: optimistic delete + `removeRecipeItemAction`
+- Ingredient swap: clicking the ingredient cell opens the picker re-targeted at that row; selection calls a combined remove+add or a dedicated `replaceRecipeItemAction` (TBD: probably a remove+add for simplicity)
+- Drag-drop: optimistic reorder, debounced 800 ms `reorderRecipeItemsAction` with the new orderedItemIds
+
+#### Picker (`<IngredientPicker>`)
+
+Dual-mode `<Command>` palette ([src/components/ui/command.tsx](src/components/ui/command.tsx)) with a tab strip at the top:
+
+**Tab 1: "Ingrediencie"** (default)
+- Fuzzy search across ingredients + sub-recipes in one list
+  - Search uses Phase B's pg_trgm + unaccent: "muka" matches "Hladká múka T650"
+- Sub-recipes shown with `📦` prefix and "Subrecept" pill
+- Filters out:
+  - Already-used items in the current recipe
+  - Sub-recipes that fail `canAddSubRecipe` (self / cycle / depth)
+  - Inactive ingredients
+- **Pinned to top:**
+  - "Naposledy použité" (last 7 days for this user) — persisted in `localStorage` under `recipe-builder:recent:${userId}` (max 10)
+  - "Najčastejšie" — global top-10 by usage count across all recipes, fetched from a new cached query `getMostUsedIngredients()` (tag `recipes`, refreshed on any recipe edit)
+- Bottom action: `+ Vytvoriť novú ingredienciu "<query>"` when there's no exact match — opens `<InlineIngredientSheet>`
+
+**Tab 2: "Z iného receptu"**
+- Searchable list of all published recipes (both `kind=product` and `kind=sub_recipe`)
+- Selecting a source recipe shows a preview of its items
+- `[Pridať všetky položky]` button calls `bulkAddItemsFromRecipeAction`
+- Items already in the target recipe are pre-checked-and-disabled in the preview
+- Closes the picker after success
+
+This is the killer feature for the "recipe 6+ workflow": the admin builds a new recipe by copying from an existing similar one and tweaking 2-3 quantities. See [arc overview §1](./_arc-overview.md#1-phase-sequencing) and the spike conversation.
+
+#### Inline ingredient sheet
+
+- `<Sheet>` overlay that hosts the ingredient form (reusing Phase B's `<IngredientForm>`)
+- Saves via Phase B's `createIngredientAction` returning the new ingredient
+- On save: closes sheet, re-opens picker with the new ingredient pre-selected, focus jumps to quantity input
+
+#### Live preview panel
+
+- Sticky card, ~300px wide on desktop, full-width drawer on mobile
+- Updates **client-side** on every items state change via `client-preview.ts` (wraps the resolver against an in-memory `ResolverContext` built from the page's loaded data)
+- Each successful autosave returns the server-authoritative `ResolvedCost` and reconciles. On drift, server wins, brief `Synchronizujem...` indicator
+- Sections (in order):
+  - Cost per unit (big number, EUR formatted)
+  - Batch cost + yield (units / grams)
+  - Alergény (chips, derived)
+  - **Note: nutrition section is added in Phase D — not rendered here**
+- **Warnings (yellow strip below KPIs):**
+  - "N surovín bez ceny — vypočítaná cena je neúplná" when any item in the trace has `hasPrice === false`. Click jumps to the offending row.
+  - "Šarža nemá zadanú hmotnosť (g)" when `batchYieldGrams === 0` — blocks Phase D nutrition but not Phase C cost.
+- If the resolver throws (cycle / missing / depth), preview goes to error state with a red banner: "Recept obsahuje cyklus" / "Recept presahuje 3 úrovne" / "Chýba ingrediencia"
+
+#### Mobile
+
+The whole builder renders read-only on screens narrower than `md`. Header form + items table + preview stack vertically, all inputs disabled, with a banner: "Úpravy receptu sú možné len na počítači."
+
+---
+
+### 6. Order snapshot at checkout
+
+**File:** `src/features/orders/actions/create-b2c-order.ts`
+
+When inserting `order_items`, populate `unitCostCents` for each line:
+
+```typescript
+// inside the order creation action, before insert(orderItems)
+const ctx = await getResolverContext();
+const items = cartItems.map((cartItem) => {
+  const product = ctx.productsById.get(cartItem.productId);
+  let unitCostCents: number | null = null;
+  if (product?.recipeId) {
+    try {
+      const resolved = resolveRecipeCost(product.recipeId, ctx);
+      unitCostCents = resolved.costPerUnitCents;
+    } catch (err) {
+      log.orders.warn(
+        { err, productId: cartItem.productId, recipeId: product.recipeId },
+        "Cost snapshot failed; storing null"
+      );
+    }
+  }
+  return {
+    orderId,
+    productId: cartItem.productId,
+    quantity: cartItem.quantity,
+    price: cartItem.priceCents,
+    unitCostCents,                       // new column
+    productSnapshot: { /* existing */ },
+  };
+});
+```
+
+Cost resolution failures **must not** break checkout. Log a warning, store NULL, continue. This is the most important rule of this section: customer ordering trumps internal cost tracking.
+
+The same logic applies to B2B order creation when that lands.
+
+---
+
+### 7. Admin nav
+
+`src/app/(admin)/admin/_components/sidebar.tsx` (or wherever the admin nav lives) — add:
+
+- "Suroviny" (Phase B's ingredients page, if not already linked)
+- "Recepty" (sub-recipe list) → `/admin/recipes`
+
+Both gated to staff roles client-side; server-side guards still required on the pages themselves.
+
+---
+
+## File summary
+
+| Action | File |
+|---|---|
+| Edit | `src/db/schema.ts` — `recipes`, `recipe_items` tables; `products.recipeId`; relations (**human approval**). `order_items.unitCostCents` was already added in Phase A scaffolding. |
+| Generate | `drizzle/NNNN_recipes.sql` migration |
+| Create | `src/features/recipes/schema.ts` |
+| Create | `src/features/recipes/api/queries.ts` |
+| Create | `src/features/recipes/api/actions.ts` |
+| Create | `src/features/recipes/lib/cost-resolver.ts` |
+| Create | `src/features/recipes/lib/can-add-sub-recipe.ts` |
+| Create | `src/features/recipes/lib/client-preview.ts` |
+| Create | `src/features/recipes/components/recipe-builder.tsx` |
+| Create | `src/features/recipes/components/recipe-header-form.tsx` |
+| Create | `src/features/recipes/components/recipe-items-table.tsx` |
+| Create | `src/features/recipes/components/recipe-item-row.tsx` |
+| Create | `src/features/recipes/components/ingredient-picker.tsx` |
+| Create | `src/features/recipes/components/inline-ingredient-sheet.tsx` |
+| Create | `src/features/recipes/components/live-preview-panel.tsx` |
+| Create | `src/features/recipes/components/recipe-list-table.tsx` |
+| Create | `src/features/recipes/components/product-recipe-tab.tsx` |
+| Create | `src/app/(admin)/admin/recipes/page.tsx` |
+| Create | `src/app/(admin)/admin/recipes/[id]/page.tsx` |
+| Edit | `src/app/(admin)/admin/products/[id]/page.tsx` — tab-aware data fetch by `searchParams.tab` |
+| Edit | `src/app/(admin)/admin/products/[id]/_components/product-form.tsx` — wrap content in `<Tabs>` |
+| Edit | `src/features/orders/actions/create-b2c-order.ts` — populate `unitCostCents`; add `revalidateTag("reports")` so Phase E sees fresh data |
+| Verify | `src/lib/logger.ts` — `recipes` namespace was added in pre-A scaffolding |
+| Edit | `src/app/(admin)/admin/_components/sidebar.tsx` — nav entry for Recepty |
+| Edit | `docs/database-schema.md` — document new tables + columns |
+| Edit | `docs/features-catalog.json` — add `recipes` feature, update `lastUpdated` |
+| Add dep | `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` (~12 KB gzipped total) |
+
+---
+
+## Constraints (from `CLAUDE.md`)
+
+- **No `db.transaction()` / `db.batch()`** — Neon HTTP. Sequential writes; defensive ordering.
+- **No barrel files** — direct imports.
+- **No dynamic imports of internal modules.**
+- **Slovak language** for user-facing text; code in English.
+- **`requireRecipeEdit()` / `requireRecipeView()`** on actions and tab data fetch (admin + manager). When the baker role lands in Phase 4, the **View** guard adds it; Edit stays admin+manager. See [arc overview §4](./_arc-overview.md#4-role-matrix).
+- **Schema changes require human approval** before editing `src/db/schema.ts`.
+- **No `pnpm db:push`** — generate + migrate.
+- **Costs in cents** (integer) throughout. Formatted via `formatPrice()` only at the render boundary.
+- **Structured logging** via `log.recipes.error()` / `log.orders.warn()`.
+- **`cacheLife("hours")` + `cacheTag()`** on all queries; `revalidateTag()` after mutations.
+
+---
+
+## Performance notes
+
+- Recipe page initial payload: recipe + items + full ingredient catalog + recipe graph. With ~500 ingredients and ~50 recipes, JSON payload is ~100 KB pre-gzip. Acceptable.
+- Cost resolver runs in O(items × depth). Depth is capped at 3, so effectively linear in items.
+- Cache invalidation cascade on a single ingredient price update: `ingredients` tag → server preview recomputes for any open recipe page on next interaction. No push needed; polling-on-action is sufficient for an admin-only feature.
+- Order checkout adds one `getResolverContext()` call per order. Cached, so amortized cost is near zero.
+
+---
+
+## Risks and decisions to lock in
+
+1. **`replaceRecipeItemAction` vs remove+add.** Picking remove+add for simplicity; if optimistic UI feels janky during ingredient swap, refactor later.
+2. **dnd-kit dependency.** ~12 KB gzipped. Confirmed worth it; alternative (up/down arrow buttons) is a worse UX for any list > 5 items.
+3. **`localStorage` for "recently used" ingredients.** Per-browser, not per-user. Acceptable for a small admin team. If multi-device sync becomes needed, move to a `user_preferences` table.
+4. **Cost snapshot on order failure.** Storing NULL when resolver throws is the safe default. Loud monitoring on the `log.orders.warn` calls so we notice patterns.
+5. **Concurrent recipe edits by two admins.** Last-write-wins per row. Real risk is low; defer presence indicators.
+6. **Recipe slug.** Auto-generated from name like products are. Useful for `/admin/recipes/by-slug/[slug]` later but unused in Phase C.
+7. **What if a sub-recipe is unpublished?** Resolver only walks `published` recipes when called from the order snapshot path. From the admin builder, we walk drafts too so the preview works while building. Two callers, two `includeDrafts` flags on `getResolverContext()`.
+
+---
+
+## Out of scope (future / Phase D / Phase E)
+
+- Nutrition derivation + display on PDP — Phase D
+- Switching PDP allergens to derived source — Phase D
+- `unitCostCents` reporting / store P&L queries — Phase E
+- Recipe scale (multiply all quantities) / find-replace ingredient across recipes
+- Recipe versioning / history (cost snapshot covers historical correctness)
+- Vector-based recipe similarity ("find recipes similar to this one") — possible Phase D+ once we have ≥50 published recipes; see [arc overview §9](./_arc-overview.md#9-fuzzy-search--duplicate-detection)
+- Per-ingredient yield loss
+- Sub-recipe presence indicator (multi-admin awareness)
+- Mobile recipe editing
+- B2B-format printable nutrition labels
+- Public-facing "Z čoho je vyrobené" ingredient list on PDP
+
+---
+
+## Acceptance criteria
+
+- [ ] Schema migration runs cleanly, no data backfill needed
+- [ ] Admin can create a sub-recipe at `/admin/recipes` and add it to a product's recipe via the picker
+- [ ] Live preview updates cost per unit + allergens within ~50 ms of typing a quantity
+- [ ] Live preview shows "N surovín bez ceny" warning when any item lacks a price
+- [ ] Resolver unit tests cover: cycle, depth-exceeded, missing ingredient, sub-recipe by mass, deep nesting, zero-priced ingredients (per [arc overview §11](./_arc-overview.md#11-testing-strategy))
+- [ ] Cycle creation is impossible from the picker; defensive resolver throws if a cycle slips in via direct DB edit
+- [ ] Depth-4 sub-recipe insertion is blocked at picker level
+- [ ] Deleting an ingredient that's used in any recipe is blocked with a clear error listing the recipes
+- [ ] **`[Duplikovať]` action on every recipe** creates a draft copy and redirects
+- [ ] **Picker "Z iného receptu" mode** imports all items from a source recipe in one click
+- [ ] Picker pins recent (per-user, localStorage) + most-frequent (global, cached query)
+- [ ] Picker search is diacritic-free via pg_trgm: "muka" finds "Hladká múka T650"
+- [ ] New B2C order has non-null `unitCostCents` on `order_items` when the product has a published recipe
+- [ ] Order creation continues without error when a recipe is missing or has resolver issues (NULL stored, warning logged)
+- [ ] Product page Recept tab is hidden for `user` role; visible for `admin` and `manager` (and `baker` after Phase 4, view-only)
+- [ ] Recipe page mobile view is read-only with a clear notice
+- [ ] All recipe queries are cached and invalidated per the [tag matrix](./_arc-overview.md#5-cache-tag-matrix)
+- [ ] No barrel files; no dynamic imports of internal modules; all actions guard with `requireRecipeEdit()`

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "migrate:images:prod": "pnpm dlx tsx scripts/migrate-product-images.ts prod",
     "typecheck": "pnpm tsc --noEmit && echo '✓ Types OK'",
     "test:stress": "pnpm dlx tsx scripts/stress-test-orders.ts",
+    "test:resolver": "pnpm dlx tsx src/features/recipes/lib/cost-resolver.test.ts",
     "check": "ultracite check",
     "fix": "ultracite fix",
     "prepare": "husky"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.95.2",
     "@consentify/core": "^2.0.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: ^0.95.2
+        version: 0.95.2(zod@4.3.6)
       '@consentify/core':
         specifier: ^2.0.0
         version: 2.0.0
@@ -352,6 +355,15 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@anthropic-ai/sdk@0.95.2':
+    resolution: {integrity: sha512-Egddwo3sheo1PzUrMkZnH6VkQYwS0h/b/i8vSK8Ta9M45UQipAMeDFH57dYuDAfXMEUUGeKw6CMlremgMZgrSQ==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
@@ -376,6 +388,10 @@ packages:
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
@@ -2590,6 +2606,9 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
@@ -3641,6 +3660,9 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -3851,6 +3873,10 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -4767,6 +4793,9 @@ packages:
     resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
     engines: {node: '>=0.8'}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -4855,6 +4884,9 @@ packages:
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
@@ -5056,6 +5088,13 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@anthropic-ai/sdk@0.95.2(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.3.6
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -5079,6 +5118,8 @@ snapshots:
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -7009,6 +7050,8 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -7946,6 +7989,8 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -8123,6 +8168,11 @@ snapshots:
       argparse: 2.0.1
 
   jsesc@3.1.0: {}
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
 
@@ -9148,6 +9198,11 @@ snapshots:
     dependencies:
       frac: 1.1.2
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
@@ -9210,6 +9265,8 @@ snapshots:
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
+
+  ts-algebra@2.0.0: {}
 
   tsconfig-paths@4.2.0:
     dependencies:

--- a/src/app/(admin)/admin/(dashboard)/page.tsx
+++ b/src/app/(admin)/admin/(dashboard)/page.tsx
@@ -8,6 +8,7 @@ import {
   getProductsAggregateByPickupDate,
   getRecentOrders,
 } from "@/features/admin-dashboard/api/queries";
+import { DashboardProfitWidget } from "@/features/reports/components/dashboard-profit-widget";
 import { AdminHeader } from "@/widgets/admin-header/admin-header";
 import { AttentionRequiredCard } from "../_components/attention-required-card";
 import { DashboardTopMetrics } from "../_components/dashboard-top-metrics";
@@ -103,12 +104,15 @@ export async function DashboardContent({
       </div>
 
       {/* NEW ANALYTICS ROW */}
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="grid gap-4 md:grid-cols-3">
         <Suspense fallback={<Skeleton className="h-48" />}>
           <RevenueProgressCard />
         </Suspense>
         <Suspense fallback={<Skeleton className="h-48" />}>
           <GrowthComparisonCard />
+        </Suspense>
+        <Suspense fallback={<Skeleton className="h-48" />}>
+          <DashboardProfitWidget />
         </Suspense>
       </div>
 

--- a/src/app/(admin)/admin/ingredients/[id]/page.tsx
+++ b/src/app/(admin)/admin/ingredients/[id]/page.tsx
@@ -1,0 +1,65 @@
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { FormSkeleton } from "@/components/forms/form-skeleton";
+import { getAllergens } from "@/features/allergens/api/queries";
+import {
+  getIngredientById,
+  getIngredientPriceHistory,
+} from "@/features/ingredients/api/queries";
+import { IngredientForm } from "@/features/ingredients/components/ingredient-form";
+import { PriceHistoryPanel } from "@/features/ingredients/components/price-history-panel";
+import { requireIngredientEdit } from "@/lib/auth/guards";
+import { AdminHeader } from "@/widgets/admin-header/admin-header";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+async function IngredientDetailLoader({ params }: Props) {
+  const { id } = await params;
+  const decodedId = decodeURIComponent(id);
+  const [ingredient, allergens, priceHistory] = await Promise.all([
+    getIngredientById(decodedId),
+    getAllergens(),
+    getIngredientPriceHistory(decodedId, 20),
+  ]);
+
+  if (!ingredient) {
+    notFound();
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+      <IngredientForm
+        allergens={allergens}
+        initial={ingredient}
+        variant="page"
+      />
+      <PriceHistoryPanel
+        baseUnit={ingredient.baseUnit}
+        history={priceHistory}
+      />
+    </div>
+  );
+}
+
+export default async function IngredientDetailPage({ params }: Props) {
+  await requireIngredientEdit();
+  const { id } = await params;
+  return (
+    <>
+      <AdminHeader
+        breadcrumbs={[
+          { label: "Dashboard", href: "/admin" },
+          { label: "Suroviny", href: "/admin/ingredients" },
+          { label: "Detail" },
+        ]}
+      />
+      <section className="@container/page p-4">
+        <Suspense fallback={<FormSkeleton />}>
+          <IngredientDetailLoader params={Promise.resolve({ id })} />
+        </Suspense>
+      </section>
+    </>
+  );
+}

--- a/src/app/(admin)/admin/ingredients/[id]/page.tsx
+++ b/src/app/(admin)/admin/ingredients/[id]/page.tsx
@@ -8,7 +8,6 @@ import {
 } from "@/features/ingredients/api/queries";
 import { IngredientForm } from "@/features/ingredients/components/ingredient-form";
 import { PriceHistoryPanel } from "@/features/ingredients/components/price-history-panel";
-import { requireIngredientEdit } from "@/lib/auth/guards";
 import { AdminHeader } from "@/widgets/admin-header/admin-header";
 
 interface Props {
@@ -43,9 +42,8 @@ async function IngredientDetailLoader({ params }: Props) {
   );
 }
 
-export default async function IngredientDetailPage({ params }: Props) {
-  await requireIngredientEdit();
-  const { id } = await params;
+export default function IngredientDetailPage({ params }: Props) {
+  // Middleware guards /admin/*; server actions guard mutations.
   return (
     <>
       <AdminHeader
@@ -57,7 +55,7 @@ export default async function IngredientDetailPage({ params }: Props) {
       />
       <section className="@container/page p-4">
         <Suspense fallback={<FormSkeleton />}>
-          <IngredientDetailLoader params={Promise.resolve({ id })} />
+          <IngredientDetailLoader params={params} />
         </Suspense>
       </section>
     </>

--- a/src/app/(admin)/admin/ingredients/_components/ingredients-list-filters.tsx
+++ b/src/app/(admin)/admin/ingredients/_components/ingredients-list-filters.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { SearchIcon } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * URL-driven filter row for the ingredients list. Search debounces and
+ * pushes ?search=... ; active and missing are normal selects.
+ */
+export function IngredientsListFilters() {
+  const router = useRouter();
+  const params = useSearchParams();
+
+  const [search, setSearch] = useState(params.get("search") ?? "");
+  const active = params.get("active") ?? "all";
+  const missing = params.get("missing") ?? "all";
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      const next = new URLSearchParams(params.toString());
+      if (search) {
+        next.set("search", search);
+      } else {
+        next.delete("search");
+      }
+      router.replace(`/admin/ingredients?${next.toString()}` as never);
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [search, params, router]);
+
+  const setParam = (key: string, value: string) => {
+    const next = new URLSearchParams(params.toString());
+    if (!value || value === "all") {
+      next.delete(key);
+    } else {
+      next.set(key, value);
+    }
+    router.replace(`/admin/ingredients?${next.toString()}` as never);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <div className="relative">
+        <SearchIcon className="absolute top-2.5 left-2 size-4 text-muted-foreground" />
+        <Input
+          className="w-64 pl-8"
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Hľadať surovinu (muka, mlieko...)"
+          value={search}
+        />
+      </div>
+      <Select onValueChange={(v) => setParam("active", v)} value={active}>
+        <SelectTrigger className="w-32">
+          <SelectValue placeholder="Stav" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">Všetky</SelectItem>
+          <SelectItem value="true">Aktívne</SelectItem>
+          <SelectItem value="false">Neaktívne</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select onValueChange={(v) => setParam("missing", v)} value={missing}>
+        <SelectTrigger className="w-44">
+          <SelectValue placeholder="Chýbajúce údaje" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">Všetky</SelectItem>
+          <SelectItem value="price">Bez ceny</SelectItem>
+          <SelectItem value="nutrition">Bez nutrície</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/ingredients/duplicates/page.tsx
+++ b/src/app/(admin)/admin/ingredients/duplicates/page.tsx
@@ -1,14 +1,82 @@
 import Link from "next/link";
+import { Suspense } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { getIngredientDuplicates } from "@/features/ingredients/api/queries";
-import { requireIngredientEdit } from "@/lib/auth/guards";
 import { AdminHeader } from "@/widgets/admin-header/admin-header";
 
-export default async function IngredientDuplicatesPage() {
-  await requireIngredientEdit();
+async function DuplicatesContent() {
   const pairs = await getIngredientDuplicates(0.7);
 
+  if (pairs.length === 0) {
+    return (
+      <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-6 text-center text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+        Žiadne duplicitné páry (prah 0.7).
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <table className="w-full text-sm">
+        <thead className="border-b bg-muted/40 text-left text-muted-foreground text-xs">
+          <tr>
+            <th className="px-3 py-2 font-medium">Surovina A</th>
+            <th className="px-3 py-2 font-medium">Surovina B</th>
+            <th className="px-3 py-2 font-medium">Podobnosť</th>
+            <th className="px-3 py-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {pairs.map((p) => (
+            <tr
+              className="border-b hover:bg-muted/30"
+              key={`${p.a_id}-${p.b_id}`}
+            >
+              <td className="px-3 py-2">
+                <Link
+                  className="hover:underline"
+                  href={`/admin/ingredients/${p.a_id}` as never}
+                >
+                  {p.a_name}
+                </Link>
+              </td>
+              <td className="px-3 py-2">
+                <Link
+                  className="hover:underline"
+                  href={`/admin/ingredients/${p.b_id}` as never}
+                >
+                  {p.b_name}
+                </Link>
+              </td>
+              <td className="px-3 py-2">
+                <Badge variant={p.score > 0.85 ? "destructive" : "secondary"}>
+                  {p.score.toFixed(2)}
+                </Badge>
+              </td>
+              <td className="px-3 py-2 text-right">
+                <Button asChild size="sm" variant="ghost">
+                  <Link href={`/admin/ingredients/${p.a_id}` as never}>
+                    Otvoriť A
+                  </Link>
+                </Button>
+                <Button asChild size="sm" variant="ghost">
+                  <Link href={`/admin/ingredients/${p.b_id}` as never}>
+                    Otvoriť B
+                  </Link>
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function IngredientDuplicatesPage() {
+  // Middleware guards /admin/*; server actions handle mutations.
   return (
     <>
       <AdminHeader
@@ -28,69 +96,9 @@ export default async function IngredientDuplicatesPage() {
             zlúčenie sa robí ručne (otvorte detail a porovnajte).
           </p>
         </div>
-
-        {pairs.length === 0 ? (
-          <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-6 text-center text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
-            Žiadne duplicitné páry (prah 0.7).
-          </div>
-        ) : (
-          <div className="overflow-x-auto rounded-lg border">
-            <table className="w-full text-sm">
-              <thead className="border-b bg-muted/40 text-left text-muted-foreground text-xs">
-                <tr>
-                  <th className="px-3 py-2 font-medium">Surovina A</th>
-                  <th className="px-3 py-2 font-medium">Surovina B</th>
-                  <th className="px-3 py-2 font-medium">Podobnosť</th>
-                  <th className="px-3 py-2" />
-                </tr>
-              </thead>
-              <tbody>
-                {pairs.map((p) => (
-                  <tr
-                    className="border-b hover:bg-muted/30"
-                    key={`${p.a_id}-${p.b_id}`}
-                  >
-                    <td className="px-3 py-2">
-                      <Link
-                        className="hover:underline"
-                        href={`/admin/ingredients/${p.a_id}` as never}
-                      >
-                        {p.a_name}
-                      </Link>
-                    </td>
-                    <td className="px-3 py-2">
-                      <Link
-                        className="hover:underline"
-                        href={`/admin/ingredients/${p.b_id}` as never}
-                      >
-                        {p.b_name}
-                      </Link>
-                    </td>
-                    <td className="px-3 py-2">
-                      <Badge
-                        variant={p.score > 0.85 ? "destructive" : "secondary"}
-                      >
-                        {p.score.toFixed(2)}
-                      </Badge>
-                    </td>
-                    <td className="px-3 py-2 text-right">
-                      <Button asChild size="sm" variant="ghost">
-                        <Link href={`/admin/ingredients/${p.a_id}` as never}>
-                          Otvoriť A
-                        </Link>
-                      </Button>
-                      <Button asChild size="sm" variant="ghost">
-                        <Link href={`/admin/ingredients/${p.b_id}` as never}>
-                          Otvoriť B
-                        </Link>
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
+        <Suspense fallback={<Skeleton className="h-64" />}>
+          <DuplicatesContent />
+        </Suspense>
       </section>
     </>
   );

--- a/src/app/(admin)/admin/ingredients/duplicates/page.tsx
+++ b/src/app/(admin)/admin/ingredients/duplicates/page.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { getIngredientDuplicates } from "@/features/ingredients/api/queries";
+import { requireIngredientEdit } from "@/lib/auth/guards";
+import { AdminHeader } from "@/widgets/admin-header/admin-header";
+
+export default async function IngredientDuplicatesPage() {
+  await requireIngredientEdit();
+  const pairs = await getIngredientDuplicates(0.7);
+
+  return (
+    <>
+      <AdminHeader
+        breadcrumbs={[
+          { label: "Dashboard", href: "/admin" },
+          { label: "Suroviny", href: "/admin/ingredients" },
+          { label: "Duplicity" },
+        ]}
+      />
+      <section className="@container/page space-y-4 p-4">
+        <div>
+          <h2 className="font-semibold text-xl tracking-tight">
+            Možné duplicity
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            Páry surovín s vysokou podobnosťou názvu. Diagnostický nástroj —
+            zlúčenie sa robí ručne (otvorte detail a porovnajte).
+          </p>
+        </div>
+
+        {pairs.length === 0 ? (
+          <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-6 text-center text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+            Žiadne duplicitné páry (prah 0.7).
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border">
+            <table className="w-full text-sm">
+              <thead className="border-b bg-muted/40 text-left text-muted-foreground text-xs">
+                <tr>
+                  <th className="px-3 py-2 font-medium">Surovina A</th>
+                  <th className="px-3 py-2 font-medium">Surovina B</th>
+                  <th className="px-3 py-2 font-medium">Podobnosť</th>
+                  <th className="px-3 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {pairs.map((p) => (
+                  <tr
+                    className="border-b hover:bg-muted/30"
+                    key={`${p.a_id}-${p.b_id}`}
+                  >
+                    <td className="px-3 py-2">
+                      <Link
+                        className="hover:underline"
+                        href={`/admin/ingredients/${p.a_id}` as never}
+                      >
+                        {p.a_name}
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2">
+                      <Link
+                        className="hover:underline"
+                        href={`/admin/ingredients/${p.b_id}` as never}
+                      >
+                        {p.b_name}
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2">
+                      <Badge
+                        variant={p.score > 0.85 ? "destructive" : "secondary"}
+                      >
+                        {p.score.toFixed(2)}
+                      </Badge>
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <Button asChild size="sm" variant="ghost">
+                        <Link href={`/admin/ingredients/${p.a_id}` as never}>
+                          Otvoriť A
+                        </Link>
+                      </Button>
+                      <Button asChild size="sm" variant="ghost">
+                        <Link href={`/admin/ingredients/${p.b_id}` as never}>
+                          Otvoriť B
+                        </Link>
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </>
+  );
+}

--- a/src/app/(admin)/admin/ingredients/page.tsx
+++ b/src/app/(admin)/admin/ingredients/page.tsx
@@ -1,0 +1,75 @@
+import { Suspense } from "react";
+import { Button } from "@/components/ui/button";
+import { getAllergens } from "@/features/allergens/api/queries";
+import { createDraftIngredientAction } from "@/features/ingredients/api/actions";
+import { getIngredients } from "@/features/ingredients/api/queries";
+import { IngredientsTable } from "@/features/ingredients/components/ingredients-table";
+import { requireIngredientEdit } from "@/lib/auth/guards";
+import { AdminHeader } from "@/widgets/admin-header/admin-header";
+import { DataTableSkeleton } from "@/widgets/data-table/data-table-skeleton";
+import { IngredientsListFilters } from "./_components/ingredients-list-filters";
+
+interface Props {
+  searchParams: Promise<{
+    search?: string;
+    active?: string;
+    missing?: string;
+  }>;
+}
+
+async function IngredientsLoader({ searchParams }: Props) {
+  const params = await searchParams;
+  let isActive: boolean | undefined;
+  if (params.active === "true") {
+    isActive = true;
+  } else if (params.active === "false") {
+    isActive = false;
+  }
+  const opts = {
+    search: params.search,
+    isActive,
+    missingPrice: params.missing === "price",
+    missingNutrition: params.missing === "nutrition",
+  };
+
+  const [items, allergens] = await Promise.all([
+    getIngredients(opts),
+    getAllergens(),
+  ]);
+
+  return <IngredientsTable allergens={allergens} ingredients={items} />;
+}
+
+export default async function IngredientsPage({ searchParams }: Props) {
+  await requireIngredientEdit();
+
+  return (
+    <>
+      <AdminHeader
+        breadcrumbs={[
+          { label: "Dashboard", href: "/admin" },
+          { label: "Suroviny" },
+        ]}
+      />
+      <section className="@container/page space-y-4 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <IngredientsListFilters />
+          <div className="flex items-center gap-2">
+            <Button asChild size="sm" variant="outline">
+              <a href="/admin/ingredients/duplicates">Duplicity</a>
+            </Button>
+            <form action={createDraftIngredientAction}>
+              <Button size="sm" type="submit">
+                + Nová surovina
+              </Button>
+            </form>
+          </div>
+        </div>
+
+        <Suspense fallback={<DataTableSkeleton columnCount={6} rowCount={8} />}>
+          <IngredientsLoader searchParams={searchParams} />
+        </Suspense>
+      </section>
+    </>
+  );
+}

--- a/src/app/(admin)/admin/ingredients/page.tsx
+++ b/src/app/(admin)/admin/ingredients/page.tsx
@@ -4,7 +4,6 @@ import { getAllergens } from "@/features/allergens/api/queries";
 import { createDraftIngredientAction } from "@/features/ingredients/api/actions";
 import { getIngredients } from "@/features/ingredients/api/queries";
 import { IngredientsTable } from "@/features/ingredients/components/ingredients-table";
-import { requireIngredientEdit } from "@/lib/auth/guards";
 import { AdminHeader } from "@/widgets/admin-header/admin-header";
 import { DataTableSkeleton } from "@/widgets/data-table/data-table-skeleton";
 import { IngredientsListFilters } from "./_components/ingredients-list-filters";
@@ -40,9 +39,11 @@ async function IngredientsLoader({ searchParams }: Props) {
   return <IngredientsTable allergens={allergens} ingredients={items} />;
 }
 
-export default async function IngredientsPage({ searchParams }: Props) {
-  await requireIngredientEdit();
-
+export default function IngredientsPage({ searchParams }: Props) {
+  // Middleware (src/proxy.ts) guards /admin/* page navigation; per CLAUDE.md
+  // we don't call auth guards in pages — they trigger cacheComponents
+  // "uncached data outside Suspense" build errors. Server actions still
+  // require their own requireIngredientEdit() guard.
   return (
     <>
       <AdminHeader
@@ -53,7 +54,9 @@ export default async function IngredientsPage({ searchParams }: Props) {
       />
       <section className="@container/page space-y-4 p-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <IngredientsListFilters />
+          <Suspense fallback={<div className="h-9 w-64" />}>
+            <IngredientsListFilters />
+          </Suspense>
           <div className="flex items-center gap-2">
             <Button asChild size="sm" variant="outline">
               <a href="/admin/ingredients/duplicates">Duplicity</a>

--- a/src/app/(admin)/admin/products/[id]/_components/product-form.tsx
+++ b/src/app/(admin)/admin/products/[id]/_components/product-form.tsx
@@ -27,6 +27,7 @@ import type { Allergen } from "@/features/allergens/api/queries";
 import { AllergenPicker } from "@/features/allergens/components/allergen-picker";
 import { allergenCodeSchema } from "@/features/allergens/schema";
 import type { Category } from "@/features/categories/api/queries";
+import { nutritionPer100Schema } from "@/features/ingredients/schema";
 import { updateProductAction } from "@/features/products/api/actions";
 import type { AdminProduct } from "@/features/products/api/queries";
 import { MAX_STRING_LENGTH, PRODUCT_STATUSES_LABELS } from "@/lib/constants";
@@ -46,6 +47,9 @@ export const productSchema = z.object({
   imageId: z.string().nullable(),
   categoryId: z.string().nullable(),
   allergenCodes: z.array(allergenCodeSchema),
+  // Phase D: full override UI is a follow-up; for now the value
+  // passes through as-is so we don't clobber DB-edited values.
+  nutritionOverride: nutritionPer100Schema.nullable(),
 });
 
 export type ProductSchema = z.infer<typeof productSchema>;
@@ -92,6 +96,9 @@ export function ProductForm({
       categoryId: product.category?.id ?? null,
       allergenCodes: (product.allergenCodes ??
         []) as ProductSchema["allergenCodes"],
+      nutritionOverride:
+        (product as { nutritionOverride?: ProductSchema["nutritionOverride"] })
+          .nutritionOverride ?? null,
     },
   });
 

--- a/src/app/(admin)/admin/products/[id]/_components/product-form.tsx
+++ b/src/app/(admin)/admin/products/[id]/_components/product-form.tsx
@@ -23,6 +23,9 @@ import {
   FieldSet,
 } from "@/components/ui/field";
 import { PRODUCT_STATUSES } from "@/db/types";
+import type { Allergen } from "@/features/allergens/api/queries";
+import { AllergenPicker } from "@/features/allergens/components/allergen-picker";
+import { allergenCodeSchema } from "@/features/allergens/schema";
 import type { Category } from "@/features/categories/api/queries";
 import { updateProductAction } from "@/features/products/api/actions";
 import type { AdminProduct } from "@/features/products/api/queries";
@@ -42,6 +45,7 @@ export const productSchema = z.object({
   priceCents: z.number(),
   imageId: z.string().nullable(),
   categoryId: z.string().nullable(),
+  allergenCodes: z.array(allergenCodeSchema),
 });
 
 export type ProductSchema = z.infer<typeof productSchema>;
@@ -49,12 +53,14 @@ export type ProductSchema = z.infer<typeof productSchema>;
 export function ProductForm({
   product,
   categories,
+  allergens,
   formId,
   renderFooter,
   className,
 }: {
   product: AdminProduct;
   categories: Category[];
+  allergens: Allergen[];
   formId: string;
   renderFooter: (props: { isPending: boolean }) => ReactNode;
   className?: string;
@@ -84,6 +90,8 @@ export function ProductForm({
       priceCents: product.priceCents,
       imageId: product.imageId ?? null,
       categoryId: product.category?.id ?? null,
+      allergenCodes: (product.allergenCodes ??
+        []) as ProductSchema["allergenCodes"],
     },
   });
 
@@ -147,6 +155,19 @@ export function ProductForm({
               />
               <PriceInputField label="Cena" name="priceCents" />
             </FieldGroup>
+          </FieldSet>
+
+          <FieldSet className="@xl/page:gap-8 gap-4">
+            <FieldLabel>Alergény</FieldLabel>
+            <FieldDescription>
+              Vyberte alergény, ktoré produkt obsahuje. Zoznam pochádza z
+              povinných 14 alergénov podľa nariadenia EÚ 1169/2011.
+            </FieldDescription>
+            <AllergenPicker
+              allergens={allergens}
+              label=""
+              name="allergenCodes"
+            />
           </FieldSet>
 
           <FieldSet className="@xl/page:gap-8 gap-4">

--- a/src/app/(admin)/admin/products/[id]/form-container.tsx
+++ b/src/app/(admin)/admin/products/[id]/form-container.tsx
@@ -4,19 +4,22 @@ import { useId } from "react";
 import { Button } from "@/components/ui/button";
 import { Kbd } from "@/components/ui/kbd";
 import { Spinner } from "@/components/ui/spinner";
+import type { Allergen } from "@/features/allergens/api/queries";
 import type { Category } from "@/features/categories/api/queries";
 import type { AdminProduct } from "@/features/products/api/queries";
 import { ProductForm } from "./_components/product-form";
 
 interface Props {
+  allergens: Allergen[];
   categories: Category[];
   product: AdminProduct;
 }
 
-export function FormContainer({ categories, product }: Props) {
+export function FormContainer({ categories, allergens, product }: Props) {
   const formId = useId();
   return (
     <ProductForm
+      allergens={allergens}
       categories={categories}
       formId={formId}
       product={product}

--- a/src/app/(admin)/admin/products/[id]/page.tsx
+++ b/src/app/(admin)/admin/products/[id]/page.tsx
@@ -4,6 +4,13 @@ import { FormSkeleton } from "@/components/forms/form-skeleton";
 import { getAllergens } from "@/features/allergens/api/queries";
 import { getAdminCategories } from "@/features/categories/api/queries";
 import { getAdminProductById } from "@/features/products/api/queries";
+import {
+  getRecipeById,
+  getRecipes,
+  getResolverContext,
+} from "@/features/recipes/api/queries";
+import { ProductRecipeCard } from "@/features/recipes/components/product-recipe-card";
+import { resolveRecipeCost } from "@/features/recipes/lib/cost-resolver";
 import { AdminHeader } from "@/widgets/admin-header/admin-header";
 import { FormContainer } from "./form-container";
 
@@ -24,13 +31,72 @@ async function ProductFormLoader({ params }: Props) {
   if (!product) {
     notFound();
   }
+
+  // Build the Recept card data in parallel with the form.
+  const recipeCard = await loadRecipeCard(product.id, product.recipeId ?? null);
+
   return (
-    <FormContainer
-      allergens={allergens}
-      categories={categories}
-      product={product}
-    />
+    <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+      <FormContainer
+        allergens={allergens}
+        categories={categories}
+        product={product}
+      />
+      <ProductRecipeCard
+        availableProductRecipes={recipeCard.availableProductRecipes}
+        linkedRecipe={recipeCard.linkedRecipe}
+        productId={product.id}
+      />
+    </div>
   );
+}
+
+async function loadRecipeCard(_productId: string, recipeId: string | null) {
+  const allProductRecipes = await getRecipes({ kind: "product" });
+
+  if (!recipeId) {
+    return {
+      linkedRecipe: null,
+      availableProductRecipes: allProductRecipes.map((r) => ({
+        id: r.id,
+        name: r.name,
+      })),
+    };
+  }
+
+  const [recipeRow, ctx] = await Promise.all([
+    getRecipeById(recipeId),
+    getResolverContext({ includeDrafts: true }),
+  ]);
+
+  let costPerUnitCents: number | null = null;
+  let resolverError: string | null = null;
+  try {
+    if (recipeRow) {
+      const resolved = resolveRecipeCost(recipeRow.recipe.id, ctx);
+      costPerUnitCents = resolved.costPerUnitCents;
+    } else {
+      resolverError = "Pripojený recept neexistuje.";
+    }
+  } catch (err) {
+    resolverError =
+      err instanceof Error ? err.message : "Výpočet nákladov receptu zlyhal.";
+  }
+
+  return {
+    linkedRecipe: recipeRow
+      ? {
+          id: recipeRow.recipe.id,
+          name: recipeRow.recipe.name,
+          status: recipeRow.recipe.status,
+          costPerUnitCents,
+          resolverError,
+        }
+      : null,
+    availableProductRecipes: allProductRecipes
+      .filter((r) => r.id !== recipeId)
+      .map((r) => ({ id: r.id, name: r.name })),
+  };
 }
 export default function B2CProductPage({ params }: Props) {
   return (

--- a/src/app/(admin)/admin/products/[id]/page.tsx
+++ b/src/app/(admin)/admin/products/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { FormSkeleton } from "@/components/forms/form-skeleton";
+import { getAllergens } from "@/features/allergens/api/queries";
 import { getAdminCategories } from "@/features/categories/api/queries";
 import { getAdminProductById } from "@/features/products/api/queries";
 import { AdminHeader } from "@/widgets/admin-header/admin-header";
@@ -15,14 +16,21 @@ interface Props {
 async function ProductFormLoader({ params }: Props) {
   const { id } = await params;
   const decodedId = decodeURIComponent(id);
-  const [product, categories] = await Promise.all([
+  const [product, categories, allergens] = await Promise.all([
     getAdminProductById(decodedId),
     getAdminCategories(),
+    getAllergens(),
   ]);
   if (!product) {
     notFound();
   }
-  return <FormContainer categories={categories} product={product} />;
+  return (
+    <FormContainer
+      allergens={allergens}
+      categories={categories}
+      product={product}
+    />
+  );
 }
 export default function B2CProductPage({ params }: Props) {
   return (

--- a/src/app/(admin)/admin/products/page.tsx
+++ b/src/app/(admin)/admin/products/page.tsx
@@ -2,6 +2,7 @@ import type { SearchParams } from "nuqs/server";
 import { Suspense } from "react";
 import { EditProductSheet } from "@/components/sheets/edit-product-sheet";
 import { ProductsTable } from "@/components/tables/products/table";
+import { getAllergens } from "@/features/allergens/api/queries";
 import { getAdminCategories } from "@/features/categories/api/queries";
 import {
   getAdminProductById,
@@ -21,12 +22,21 @@ async function ProductSheetLoader({
   searchParams: Promise<SearchParams>;
 }) {
   const { productId } = await searchParams;
-  const product = await getAdminProductById(productId as string);
-  const categories = await getAdminCategories();
+  const [product, categories, allergens] = await Promise.all([
+    getAdminProductById(productId as string),
+    getAdminCategories(),
+    getAllergens(),
+  ]);
   if (!product) {
     return null;
   }
-  return <EditProductSheet categories={categories} product={product} />;
+  return (
+    <EditProductSheet
+      allergens={allergens}
+      categories={categories}
+      product={product}
+    />
+  );
 }
 
 export default function ProductsPage({

--- a/src/app/(admin)/admin/recipes/[id]/page.tsx
+++ b/src/app/(admin)/admin/recipes/[id]/page.tsx
@@ -1,0 +1,107 @@
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+import { FormSkeleton } from "@/components/forms/form-skeleton";
+import { getAllergens } from "@/features/allergens/api/queries";
+import {
+  getMostUsedIngredients,
+  getRecipeById,
+  getRecipeGraph,
+  getRecipes,
+  getResolverContext,
+} from "@/features/recipes/api/queries";
+import { RecipeBuilder } from "@/features/recipes/components/recipe-builder";
+import { requireRecipeView } from "@/lib/auth/guards";
+import { AdminHeader } from "@/widgets/admin-header/admin-header";
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+async function RecipeDetailLoader({ params }: Props) {
+  const { id } = await params;
+  const decodedId = decodeURIComponent(id);
+
+  const [recipeWithItems, allergens, ctx, graph, mostUsed, allSubRecipes] =
+    await Promise.all([
+      getRecipeById(decodedId),
+      getAllergens(),
+      getResolverContext({ includeDrafts: true }),
+      getRecipeGraph(),
+      getMostUsedIngredients(10),
+      getRecipes({ kind: "sub_recipe" }),
+    ]);
+
+  if (!recipeWithItems) {
+    notFound();
+  }
+  const { recipe, items } = recipeWithItems;
+
+  // Plain Map for the picker's cycle check (mutable form expected by canAddSubRecipe).
+  const recipesGraph = new Map<string, string[]>();
+  for (const [k, v] of graph.entries()) {
+    recipesGraph.set(k, v);
+  }
+
+  const pickerIngredients = Array.from(ctx.ingredients.values()).map((i) => ({
+    id: i.id,
+    name: i.name,
+    baseUnit: i.baseUnit,
+  }));
+
+  const pickerSubRecipes = allSubRecipes
+    .filter((r) => r.id !== recipe.id)
+    .map((r) => ({ id: r.id, name: r.name }));
+
+  const initialHeader = {
+    name: recipe.name,
+    slug: recipe.slug,
+    kind: recipe.kind,
+    status: recipe.status,
+    batchYieldUnits: recipe.batchYieldUnits,
+    batchYieldGrams: recipe.batchYieldGrams,
+    yieldLossPercent: recipe.yieldLossPercent,
+    notes: recipe.notes,
+  };
+
+  return (
+    <RecipeBuilder
+      allergens={allergens}
+      ingredientsMap={ctx.ingredients as Map<string, never>}
+      initialHeader={initialHeader}
+      initialItems={items.map((it) => ({
+        id: it.id,
+        ingredientId: it.ingredientId,
+        subRecipeId: it.subRecipeId,
+        quantityBaseUnit: it.quantityBaseUnit,
+        sortOrder: it.sortOrder,
+      }))}
+      mostUsedIds={mostUsed.map((m) => m.id)}
+      pickerIngredients={pickerIngredients}
+      pickerSubRecipes={pickerSubRecipes}
+      recipeId={recipe.id}
+      recipesGraph={recipesGraph}
+      recipesMap={ctx.recipes as Map<string, never>}
+    />
+  );
+}
+
+export default async function RecipeDetailPage({ params }: Props) {
+  await requireRecipeView();
+  const { id } = await params;
+  return (
+    <>
+      <AdminHeader
+        breadcrumbs={[
+          { label: "Dashboard", href: "/admin" },
+          { label: "Recepty", href: "/admin/recipes" },
+          { label: "Detail" },
+        ]}
+      />
+      <section className="@container/page p-4">
+        <Suspense fallback={<FormSkeleton />}>
+          <RecipeDetailLoader params={Promise.resolve({ id })} />
+        </Suspense>
+      </section>
+    </>
+  );
+}

--- a/src/app/(admin)/admin/recipes/[id]/page.tsx
+++ b/src/app/(admin)/admin/recipes/[id]/page.tsx
@@ -10,7 +10,6 @@ import {
   getResolverContext,
 } from "@/features/recipes/api/queries";
 import { RecipeBuilder } from "@/features/recipes/components/recipe-builder";
-import { requireRecipeView } from "@/lib/auth/guards";
 import { AdminHeader } from "@/widgets/admin-header/admin-header";
 
 interface Props {
@@ -85,9 +84,8 @@ async function RecipeDetailLoader({ params }: Props) {
   );
 }
 
-export default async function RecipeDetailPage({ params }: Props) {
-  await requireRecipeView();
-  const { id } = await params;
+export default function RecipeDetailPage({ params }: Props) {
+  // Middleware guards /admin/*; server actions handle mutations.
   return (
     <>
       <AdminHeader
@@ -99,7 +97,7 @@ export default async function RecipeDetailPage({ params }: Props) {
       />
       <section className="@container/page p-4">
         <Suspense fallback={<FormSkeleton />}>
-          <RecipeDetailLoader params={Promise.resolve({ id })} />
+          <RecipeDetailLoader params={params} />
         </Suspense>
       </section>
     </>

--- a/src/app/(admin)/admin/recipes/drift/page.tsx
+++ b/src/app/(admin)/admin/recipes/drift/page.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
+import { Suspense } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { getAllergens } from "@/features/allergens/api/queries";
 import { ALLERGEN_ICONS } from "@/features/allergens/lib/icons";
 import { getAllergenDrift } from "@/features/products/api/allergen-drift";
-import { requireRecipeView } from "@/lib/auth/guards";
 import { AdminHeader } from "@/widgets/admin-header/admin-header";
 
 interface Props {
@@ -13,8 +14,7 @@ interface Props {
 
 const PAGE_SIZE = 50;
 
-export default async function AllergenDriftPage({ searchParams }: Props) {
-  await requireRecipeView();
+async function DriftContent({ searchParams }: Props) {
   const params = await searchParams;
   const offset = Number.parseInt(params.offset ?? "0", 10) || 0;
   const limit =
@@ -27,6 +27,130 @@ export default async function AllergenDriftPage({ searchParams }: Props) {
 
   const allergenByCode = new Map(allergens.map((a) => [a.code, a]));
 
+  return (
+    <>
+      {drift.items.length === 0 ? (
+        <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-6 text-center text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+          Žiadne rozdiely — všetky produkty s receptom majú alergény v poriadku.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/40 text-left text-muted-foreground text-xs">
+              <tr>
+                <th className="px-3 py-2 font-medium">Produkt</th>
+                <th className="px-3 py-2 font-medium">Ručne</th>
+                <th className="px-3 py-2 font-medium">Z receptu</th>
+                <th className="px-3 py-2 font-medium">Rozdiel</th>
+                <th className="px-3 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {drift.items.map((row) => (
+                <tr
+                  className="border-b align-top hover:bg-muted/30"
+                  key={row.productId}
+                >
+                  <td className="px-3 py-2">
+                    <Link
+                      className="font-medium hover:underline"
+                      href={`/admin/products/${row.productId}` as never}
+                    >
+                      {row.productName}
+                    </Link>
+                    {row.resolverError && (
+                      <p className="mt-0.5 text-destructive text-xs">
+                        {row.resolverError}
+                      </p>
+                    )}
+                  </td>
+                  <td className="px-3 py-2">
+                    <Chips
+                      allergenByCode={allergenByCode}
+                      codes={row.manualCodes}
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <Chips
+                      allergenByCode={allergenByCode}
+                      codes={row.derivedCodes}
+                    />
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="space-y-1">
+                      {row.added.length > 0 && (
+                        <div className="flex flex-wrap items-center gap-1">
+                          <span className="text-emerald-600 text-xs dark:text-emerald-400">
+                            +
+                          </span>
+                          <Chips
+                            allergenByCode={allergenByCode}
+                            codes={row.added}
+                            variant="success"
+                          />
+                        </div>
+                      )}
+                      {row.removed.length > 0 && (
+                        <div className="flex flex-wrap items-center gap-1">
+                          <span className="text-destructive text-xs">−</span>
+                          <Chips
+                            allergenByCode={allergenByCode}
+                            codes={row.removed}
+                            variant="destructive"
+                          />
+                        </div>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    <Button asChild size="sm" variant="ghost">
+                      <Link href={`/admin/products/${row.productId}` as never}>
+                        Otvoriť
+                      </Link>
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="flex items-center justify-between text-muted-foreground text-xs">
+        <span>
+          Strana {Math.floor(offset / limit) + 1}, položiek {drift.items.length}
+        </span>
+        <div className="flex items-center gap-2">
+          {offset > 0 && (
+            <Button asChild size="sm" variant="ghost">
+              <Link
+                href={
+                  `/admin/recipes/drift?offset=${Math.max(0, offset - limit)}&limit=${limit}` as never
+                }
+              >
+                Predchádzajúca
+              </Link>
+            </Button>
+          )}
+          {drift.items.length === limit && (
+            <Button asChild size="sm" variant="ghost">
+              <Link
+                href={
+                  `/admin/recipes/drift?offset=${offset + limit}&limit=${limit}` as never
+                }
+              >
+                Ďalšia
+              </Link>
+            </Button>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default function AllergenDriftPage({ searchParams }: Props) {
+  // Middleware guards /admin/*; server actions handle mutations.
   return (
     <>
       <AdminHeader
@@ -46,127 +170,9 @@ export default async function AllergenDriftPage({ searchParams }: Props) {
             alergénmi odvodenými zo surovín. Diagnostický nástroj.
           </p>
         </div>
-
-        {drift.items.length === 0 ? (
-          <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-6 text-center text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
-            Žiadne rozdiely — všetky produkty s receptom majú alergény v
-            poriadku.
-          </div>
-        ) : (
-          <div className="overflow-x-auto rounded-lg border">
-            <table className="w-full text-sm">
-              <thead className="border-b bg-muted/40 text-left text-muted-foreground text-xs">
-                <tr>
-                  <th className="px-3 py-2 font-medium">Produkt</th>
-                  <th className="px-3 py-2 font-medium">Ručne</th>
-                  <th className="px-3 py-2 font-medium">Z receptu</th>
-                  <th className="px-3 py-2 font-medium">Rozdiel</th>
-                  <th className="px-3 py-2" />
-                </tr>
-              </thead>
-              <tbody>
-                {drift.items.map((row) => (
-                  <tr
-                    className="border-b align-top hover:bg-muted/30"
-                    key={row.productId}
-                  >
-                    <td className="px-3 py-2">
-                      <Link
-                        className="font-medium hover:underline"
-                        href={`/admin/products/${row.productId}` as never}
-                      >
-                        {row.productName}
-                      </Link>
-                      {row.resolverError && (
-                        <p className="mt-0.5 text-destructive text-xs">
-                          {row.resolverError}
-                        </p>
-                      )}
-                    </td>
-                    <td className="px-3 py-2">
-                      <Chips
-                        allergenByCode={allergenByCode}
-                        codes={row.manualCodes}
-                      />
-                    </td>
-                    <td className="px-3 py-2">
-                      <Chips
-                        allergenByCode={allergenByCode}
-                        codes={row.derivedCodes}
-                      />
-                    </td>
-                    <td className="px-3 py-2">
-                      <div className="space-y-1">
-                        {row.added.length > 0 && (
-                          <div className="flex flex-wrap items-center gap-1">
-                            <span className="text-emerald-600 text-xs dark:text-emerald-400">
-                              +
-                            </span>
-                            <Chips
-                              allergenByCode={allergenByCode}
-                              codes={row.added}
-                              variant="success"
-                            />
-                          </div>
-                        )}
-                        {row.removed.length > 0 && (
-                          <div className="flex flex-wrap items-center gap-1">
-                            <span className="text-destructive text-xs">−</span>
-                            <Chips
-                              allergenByCode={allergenByCode}
-                              codes={row.removed}
-                              variant="destructive"
-                            />
-                          </div>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-3 py-2 text-right">
-                      <Button asChild size="sm" variant="ghost">
-                        <Link
-                          href={`/admin/products/${row.productId}` as never}
-                        >
-                          Otvoriť
-                        </Link>
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-
-        <div className="flex items-center justify-between text-muted-foreground text-xs">
-          <span>
-            Strana {Math.floor(offset / limit) + 1}, položiek{" "}
-            {drift.items.length}
-          </span>
-          <div className="flex items-center gap-2">
-            {offset > 0 && (
-              <Button asChild size="sm" variant="ghost">
-                <Link
-                  href={
-                    `/admin/recipes/drift?offset=${Math.max(0, offset - limit)}&limit=${limit}` as never
-                  }
-                >
-                  Predchádzajúca
-                </Link>
-              </Button>
-            )}
-            {drift.items.length === limit && (
-              <Button asChild size="sm" variant="ghost">
-                <Link
-                  href={
-                    `/admin/recipes/drift?offset=${offset + limit}&limit=${limit}` as never
-                  }
-                >
-                  Ďalšia
-                </Link>
-              </Button>
-            )}
-          </div>
-        </div>
+        <Suspense fallback={<Skeleton className="h-64" />}>
+          <DriftContent searchParams={searchParams} />
+        </Suspense>
       </section>
     </>
   );

--- a/src/app/(admin)/admin/recipes/drift/page.tsx
+++ b/src/app/(admin)/admin/recipes/drift/page.tsx
@@ -1,0 +1,201 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { getAllergens } from "@/features/allergens/api/queries";
+import { ALLERGEN_ICONS } from "@/features/allergens/lib/icons";
+import { getAllergenDrift } from "@/features/products/api/allergen-drift";
+import { requireRecipeView } from "@/lib/auth/guards";
+import { AdminHeader } from "@/widgets/admin-header/admin-header";
+
+interface Props {
+  searchParams: Promise<{ offset?: string; limit?: string }>;
+}
+
+const PAGE_SIZE = 50;
+
+export default async function AllergenDriftPage({ searchParams }: Props) {
+  await requireRecipeView();
+  const params = await searchParams;
+  const offset = Number.parseInt(params.offset ?? "0", 10) || 0;
+  const limit =
+    Number.parseInt(params.limit ?? String(PAGE_SIZE), 10) || PAGE_SIZE;
+
+  const [drift, allergens] = await Promise.all([
+    getAllergenDrift({ offset, limit }),
+    getAllergens(),
+  ]);
+
+  const allergenByCode = new Map(allergens.map((a) => [a.code, a]));
+
+  return (
+    <>
+      <AdminHeader
+        breadcrumbs={[
+          { label: "Dashboard", href: "/admin" },
+          { label: "Recepty", href: "/admin/recipes" },
+          { label: "Rozdiely alergénov" },
+        ]}
+      />
+      <section className="@container/page space-y-4 p-4">
+        <div>
+          <h2 className="font-semibold text-xl tracking-tight">
+            Rozdiely alergénov
+          </h2>
+          <p className="text-muted-foreground text-sm">
+            Produkty s receptom, kde sa ručne označené alergény nezhodujú s
+            alergénmi odvodenými zo surovín. Diagnostický nástroj.
+          </p>
+        </div>
+
+        {drift.items.length === 0 ? (
+          <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-6 text-center text-emerald-700 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300">
+            Žiadne rozdiely — všetky produkty s receptom majú alergény v
+            poriadku.
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border">
+            <table className="w-full text-sm">
+              <thead className="border-b bg-muted/40 text-left text-muted-foreground text-xs">
+                <tr>
+                  <th className="px-3 py-2 font-medium">Produkt</th>
+                  <th className="px-3 py-2 font-medium">Ručne</th>
+                  <th className="px-3 py-2 font-medium">Z receptu</th>
+                  <th className="px-3 py-2 font-medium">Rozdiel</th>
+                  <th className="px-3 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {drift.items.map((row) => (
+                  <tr
+                    className="border-b align-top hover:bg-muted/30"
+                    key={row.productId}
+                  >
+                    <td className="px-3 py-2">
+                      <Link
+                        className="font-medium hover:underline"
+                        href={`/admin/products/${row.productId}` as never}
+                      >
+                        {row.productName}
+                      </Link>
+                      {row.resolverError && (
+                        <p className="mt-0.5 text-destructive text-xs">
+                          {row.resolverError}
+                        </p>
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      <Chips
+                        allergenByCode={allergenByCode}
+                        codes={row.manualCodes}
+                      />
+                    </td>
+                    <td className="px-3 py-2">
+                      <Chips
+                        allergenByCode={allergenByCode}
+                        codes={row.derivedCodes}
+                      />
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="space-y-1">
+                        {row.added.length > 0 && (
+                          <div className="flex flex-wrap items-center gap-1">
+                            <span className="text-emerald-600 text-xs dark:text-emerald-400">
+                              +
+                            </span>
+                            <Chips
+                              allergenByCode={allergenByCode}
+                              codes={row.added}
+                              variant="success"
+                            />
+                          </div>
+                        )}
+                        {row.removed.length > 0 && (
+                          <div className="flex flex-wrap items-center gap-1">
+                            <span className="text-destructive text-xs">−</span>
+                            <Chips
+                              allergenByCode={allergenByCode}
+                              codes={row.removed}
+                              variant="destructive"
+                            />
+                          </div>
+                        )}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <Button asChild size="sm" variant="ghost">
+                        <Link
+                          href={`/admin/products/${row.productId}` as never}
+                        >
+                          Otvoriť
+                        </Link>
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between text-muted-foreground text-xs">
+          <span>
+            Strana {Math.floor(offset / limit) + 1}, položiek{" "}
+            {drift.items.length}
+          </span>
+          <div className="flex items-center gap-2">
+            {offset > 0 && (
+              <Button asChild size="sm" variant="ghost">
+                <Link
+                  href={
+                    `/admin/recipes/drift?offset=${Math.max(0, offset - limit)}&limit=${limit}` as never
+                  }
+                >
+                  Predchádzajúca
+                </Link>
+              </Button>
+            )}
+            {drift.items.length === limit && (
+              <Button asChild size="sm" variant="ghost">
+                <Link
+                  href={
+                    `/admin/recipes/drift?offset=${offset + limit}&limit=${limit}` as never
+                  }
+                >
+                  Ďalšia
+                </Link>
+              </Button>
+            )}
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}
+
+function Chips({
+  codes,
+  allergenByCode,
+  variant = "secondary",
+}: {
+  codes: string[];
+  allergenByCode: Map<string, { code: string; nameSk: string }>;
+  variant?: "secondary" | "success" | "destructive";
+}) {
+  if (codes.length === 0) {
+    return <span className="text-muted-foreground text-xs">—</span>;
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {codes.map((code) => {
+        const a = allergenByCode.get(code);
+        const Icon = ALLERGEN_ICONS[code as keyof typeof ALLERGEN_ICONS];
+        return (
+          <Badge className="gap-1 text-[10px]" key={code} variant={variant}>
+            {Icon && <Icon className="size-3" />}
+            {a?.nameSk ?? code}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/recipes/page.tsx
+++ b/src/app/(admin)/admin/recipes/page.tsx
@@ -4,7 +4,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { createRecipeAction } from "@/features/recipes/api/actions";
 import { getRecipes } from "@/features/recipes/api/queries";
-import { requireRecipeView } from "@/lib/auth/guards";
 import { AdminHeader } from "@/widgets/admin-header/admin-header";
 import { DataTableSkeleton } from "@/widgets/data-table/data-table-skeleton";
 
@@ -70,9 +69,8 @@ async function RecipesLoader() {
   );
 }
 
-export default async function RecipesPage() {
-  await requireRecipeView();
-
+export default function RecipesPage() {
+  // Middleware guards /admin/*; server actions handle mutations.
   return (
     <>
       <AdminHeader

--- a/src/app/(admin)/admin/recipes/page.tsx
+++ b/src/app/(admin)/admin/recipes/page.tsx
@@ -82,7 +82,10 @@ export default async function RecipesPage() {
         ]}
       />
       <section className="@container/page space-y-4 p-4">
-        <div className="flex items-center justify-end">
+        <div className="flex items-center justify-end gap-2">
+          <Button asChild size="sm" variant="outline">
+            <a href="/admin/recipes/drift">Rozdiely alergénov</a>
+          </Button>
           <form action={createSubRecipe}>
             <Button size="sm" type="submit">
               + Nový subrecept

--- a/src/app/(admin)/admin/recipes/page.tsx
+++ b/src/app/(admin)/admin/recipes/page.tsx
@@ -1,0 +1,104 @@
+import Link from "next/link";
+import { Suspense } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { createRecipeAction } from "@/features/recipes/api/actions";
+import { getRecipes } from "@/features/recipes/api/queries";
+import { requireRecipeView } from "@/lib/auth/guards";
+import { AdminHeader } from "@/widgets/admin-header/admin-header";
+import { DataTableSkeleton } from "@/widgets/data-table/data-table-skeleton";
+
+async function RecipesLoader() {
+  const all = await getRecipes();
+
+  if (all.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+        Žiadne recepty. Vytvorte prvý cez „Nový recept".
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <table className="w-full text-sm">
+        <thead className="border-b bg-muted/40 text-left text-muted-foreground text-xs">
+          <tr>
+            <th className="px-3 py-2 font-medium">Názov</th>
+            <th className="px-3 py-2 font-medium">Typ</th>
+            <th className="px-3 py-2 font-medium">Stav</th>
+            <th className="px-3 py-2 font-medium">Výnos</th>
+            <th className="px-3 py-2 font-medium">Upravené</th>
+          </tr>
+        </thead>
+        <tbody>
+          {all.map((r) => (
+            <tr className="border-b hover:bg-muted/30" key={r.id}>
+              <td className="px-3 py-2">
+                <Link
+                  className="font-medium hover:underline"
+                  href={`/admin/recipes/${r.id}` as never}
+                >
+                  {r.name}
+                </Link>
+              </td>
+              <td className="px-3 py-2">
+                <Badge variant={r.kind === "product" ? "default" : "secondary"}>
+                  {r.kind === "product" ? "Produkt" : "Subrecept"}
+                </Badge>
+              </td>
+              <td className="px-3 py-2">
+                <Badge
+                  variant={r.status === "published" ? "success" : "outline"}
+                >
+                  {r.status === "published" ? "Publikovaný" : "Koncept"}
+                </Badge>
+              </td>
+              <td className="px-3 py-2 text-muted-foreground text-xs">
+                {r.batchYieldUnits} ks / {r.batchYieldGrams} g
+              </td>
+              <td className="px-3 py-2 text-muted-foreground text-xs">
+                {new Intl.DateTimeFormat("sk-SK", {
+                  dateStyle: "medium",
+                }).format(new Date(r.updatedAt))}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default async function RecipesPage() {
+  await requireRecipeView();
+
+  return (
+    <>
+      <AdminHeader
+        breadcrumbs={[
+          { label: "Dashboard", href: "/admin" },
+          { label: "Recepty" },
+        ]}
+      />
+      <section className="@container/page space-y-4 p-4">
+        <div className="flex items-center justify-end">
+          <form action={createSubRecipe}>
+            <Button size="sm" type="submit">
+              + Nový subrecept
+            </Button>
+          </form>
+        </div>
+
+        <Suspense fallback={<DataTableSkeleton columnCount={5} rowCount={6} />}>
+          <RecipesLoader />
+        </Suspense>
+      </section>
+    </>
+  );
+}
+
+async function createSubRecipe() {
+  "use server";
+  await createRecipeAction({ kind: "sub_recipe" });
+}

--- a/src/app/(admin)/admin/reports/page.tsx
+++ b/src/app/(admin)/admin/reports/page.tsx
@@ -1,0 +1,99 @@
+import { BarChart3Icon, PackageIcon, StoreIcon } from "lucide-react";
+import Link from "next/link";
+import { Suspense } from "react";
+import { getProfitabilitySummary } from "@/features/reports/api/queries";
+import { KpiCard } from "@/features/reports/components/kpi-card";
+import {
+  formatEur,
+  formatPct,
+  marginColor,
+} from "@/features/reports/lib/format";
+import { resolvePeriod } from "@/features/reports/lib/period";
+import { requireReportsView } from "@/lib/auth/guards";
+import { AdminHeader } from "@/widgets/admin-header/admin-header";
+
+async function SummaryStrip() {
+  const period = resolvePeriod("30d");
+  const summary = await getProfitabilitySummary(period);
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <KpiCard
+        hint="Posledných 30 dní"
+        label="Tržby"
+        value={formatEur(summary.revenueCents)}
+      />
+      <KpiCard label="Náklady" value={formatEur(summary.costCents)} />
+      <KpiCard label="Marža (€)" value={formatEur(summary.marginCents)} />
+      <KpiCard
+        className={marginColor(summary.marginPct)}
+        label="Marža %"
+        value={formatPct(summary.marginPct)}
+      />
+    </div>
+  );
+}
+
+const REPORT_LINKS = [
+  {
+    href: "/admin/reports/profitability/stores",
+    label: "Ziskovosť predajní",
+    description: "Tržby, náklady a marža podľa predajne.",
+    icon: StoreIcon,
+  },
+  {
+    href: "/admin/reports/profitability/products",
+    label: "Ziskovosť produktov",
+    description:
+      "Ktoré produkty zarábajú najviac. Zoradené podľa hrubej marže.",
+    icon: PackageIcon,
+  },
+] as const;
+
+export default async function ReportsLandingPage() {
+  await requireReportsView();
+
+  return (
+    <>
+      <AdminHeader
+        breadcrumbs={[
+          { label: "Dashboard", href: "/admin" },
+          { label: "Reporty" },
+        ]}
+      />
+      <section className="@container/page space-y-6 p-4">
+        <Suspense
+          fallback={
+            <div className="h-24 animate-pulse rounded-lg bg-muted/40" />
+          }
+        >
+          <SummaryStrip />
+        </Suspense>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          {REPORT_LINKS.map((r) => {
+            const Icon = r.icon;
+            return (
+              <Link
+                className="group rounded-lg border bg-card p-4 transition-colors hover:bg-accent"
+                href={r.href as never}
+                key={r.href}
+              >
+                <div className="mb-2 flex items-center gap-2">
+                  <Icon className="size-5 text-muted-foreground group-hover:text-foreground" />
+                  <h3 className="font-semibold text-sm">{r.label}</h3>
+                </div>
+                <p className="text-muted-foreground text-xs">{r.description}</p>
+              </Link>
+            );
+          })}
+        </div>
+
+        <p className="flex items-center gap-1.5 text-muted-foreground text-xs">
+          <BarChart3Icon className="size-3" />
+          Reporty používajú hrubú maržu (tržby − náklady na výrobu). Réžia, mzdy
+          a iné prevádzkové náklady tu nie sú zahrnuté.
+        </p>
+      </section>
+    </>
+  );
+}

--- a/src/app/(admin)/admin/reports/page.tsx
+++ b/src/app/(admin)/admin/reports/page.tsx
@@ -1,37 +1,6 @@
 import { BarChart3Icon, PackageIcon, StoreIcon } from "lucide-react";
 import Link from "next/link";
-import { Suspense } from "react";
-import { getProfitabilitySummary } from "@/features/reports/api/queries";
-import { KpiCard } from "@/features/reports/components/kpi-card";
-import {
-  formatEur,
-  formatPct,
-  marginColor,
-} from "@/features/reports/lib/format";
-import { resolvePeriod } from "@/features/reports/lib/period";
-import { requireReportsView } from "@/lib/auth/guards";
 import { AdminHeader } from "@/widgets/admin-header/admin-header";
-
-async function SummaryStrip() {
-  const period = resolvePeriod("30d");
-  const summary = await getProfitabilitySummary(period);
-  return (
-    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-      <KpiCard
-        hint="Posledných 30 dní"
-        label="Tržby"
-        value={formatEur(summary.revenueCents)}
-      />
-      <KpiCard label="Náklady" value={formatEur(summary.costCents)} />
-      <KpiCard label="Marža (€)" value={formatEur(summary.marginCents)} />
-      <KpiCard
-        className={marginColor(summary.marginPct)}
-        label="Marža %"
-        value={formatPct(summary.marginPct)}
-      />
-    </div>
-  );
-}
 
 const REPORT_LINKS = [
   {
@@ -49,9 +18,11 @@ const REPORT_LINKS = [
   },
 ] as const;
 
-export default async function ReportsLandingPage() {
-  await requireReportsView();
-
+export default function ReportsLandingPage() {
+  // Middleware guards /admin/*; route handlers / actions guard their own
+  // paths. Summary KPIs live on the /admin dashboard widget — duplicating
+  // them here would force new Date() into a server component before any
+  // uncached read, which Next.js 16 cacheComponents disallows.
   return (
     <>
       <AdminHeader
@@ -61,14 +32,6 @@ export default async function ReportsLandingPage() {
         ]}
       />
       <section className="@container/page space-y-6 p-4">
-        <Suspense
-          fallback={
-            <div className="h-24 animate-pulse rounded-lg bg-muted/40" />
-          }
-        >
-          <SummaryStrip />
-        </Suspense>
-
         <div className="grid gap-3 sm:grid-cols-2">
           {REPORT_LINKS.map((r) => {
             const Icon = r.icon;

--- a/src/app/(admin)/admin/reports/profitability/products/page.tsx
+++ b/src/app/(admin)/admin/reports/profitability/products/page.tsx
@@ -1,0 +1,135 @@
+import { DownloadIcon } from "lucide-react";
+import { Suspense } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  getProductProfitability,
+  getProfitabilitySummary,
+} from "@/features/reports/api/queries";
+import { KpiCard } from "@/features/reports/components/kpi-card";
+import { PeriodPicker } from "@/features/reports/components/period-picker";
+import {
+  formatEur,
+  formatPct,
+  marginColor,
+} from "@/features/reports/lib/format";
+import { resolvePeriod } from "@/features/reports/lib/period";
+import { requireReportsView } from "@/lib/auth/guards";
+import { AdminHeader } from "@/widgets/admin-header/admin-header";
+
+interface Props {
+  searchParams: Promise<{ period?: string; minQty?: string }>;
+}
+
+async function ProductReport({ searchParams }: Props) {
+  const params = await searchParams;
+  const preset =
+    (params.period as "7d" | "30d" | "90d" | "mtd" | "ytd" | undefined) ??
+    "30d";
+  const period = resolvePeriod(preset);
+  const minQty = Number.parseInt(params.minQty ?? "0", 10) || 0;
+
+  const [summary, rows] = await Promise.all([
+    getProfitabilitySummary(period),
+    getProductProfitability(period, { minQuantity: minQty }),
+  ]);
+
+  return (
+    <>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard label="Tržby" value={formatEur(summary.revenueCents)} />
+        <KpiCard label="Náklady" value={formatEur(summary.costCents)} />
+        <KpiCard label="Marža (€)" value={formatEur(summary.marginCents)} />
+        <KpiCard label="Marža %" value={formatPct(summary.marginPct)} />
+      </div>
+
+      {rows.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+          V zvolenom období neboli žiadne predaje.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/40 text-left text-muted-foreground text-xs">
+              <tr>
+                <th className="px-3 py-2 font-medium">Produkt</th>
+                <th className="px-3 py-2 font-medium">Kategória</th>
+                <th className="px-3 py-2 text-right font-medium">Predané</th>
+                <th className="px-3 py-2 text-right font-medium">Tržby</th>
+                <th className="px-3 py-2 text-right font-medium">Náklady</th>
+                <th className="px-3 py-2 text-right font-medium">Marža</th>
+                <th className="px-3 py-2 text-right font-medium">Marža %</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr className="border-b hover:bg-muted/30" key={r.productId}>
+                  <td className="px-3 py-2 font-medium">{r.productName}</td>
+                  <td className="px-3 py-2 text-muted-foreground text-xs">
+                    {r.categoryName ?? "—"}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums">
+                    {r.quantitySold}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums">
+                    {formatEur(r.revenueCents)}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums">
+                    {formatEur(r.costCents)}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums">
+                    {formatEur(r.marginCents)}
+                  </td>
+                  <td
+                    className={`px-3 py-2 text-right tabular-nums ${marginColor(r.marginPct)}`}
+                  >
+                    {formatPct(r.marginPct)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default async function ProductProfitabilityPage({
+  searchParams,
+}: Props) {
+  await requireReportsView();
+  const params = await searchParams;
+  const preset = params.period ?? "30d";
+
+  return (
+    <>
+      <AdminHeader
+        breadcrumbs={[
+          { label: "Dashboard", href: "/admin" },
+          { label: "Reporty", href: "/admin/reports" },
+          { label: "Ziskovosť produktov" },
+        ]}
+      />
+      <section className="@container/page space-y-4 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <PeriodPicker basePath="/admin/reports/profitability/products" />
+          <Button asChild size="sm" variant="outline">
+            <a
+              href={`/api/admin/reports/export?report=products&period=${preset}`}
+            >
+              <DownloadIcon className="mr-1.5 size-4" />
+              Stiahnuť CSV
+            </a>
+          </Button>
+        </div>
+        <Suspense
+          fallback={
+            <div className="h-64 animate-pulse rounded-lg bg-muted/40" />
+          }
+        >
+          <ProductReport searchParams={Promise.resolve(params)} />
+        </Suspense>
+      </section>
+    </>
+  );
+}

--- a/src/app/(admin)/admin/reports/profitability/products/page.tsx
+++ b/src/app/(admin)/admin/reports/profitability/products/page.tsx
@@ -13,7 +13,6 @@ import {
   marginColor,
 } from "@/features/reports/lib/format";
 import { resolvePeriod } from "@/features/reports/lib/period";
-import { requireReportsView } from "@/lib/auth/guards";
 import { AdminHeader } from "@/widgets/admin-header/admin-header";
 
 interface Props {
@@ -94,13 +93,21 @@ async function ProductReport({ searchParams }: Props) {
   );
 }
 
-export default async function ProductProfitabilityPage({
-  searchParams,
-}: Props) {
-  await requireReportsView();
+async function ExportButton({ searchParams }: Props) {
   const params = await searchParams;
   const preset = params.period ?? "30d";
+  return (
+    <Button asChild size="sm" variant="outline">
+      <a href={`/api/admin/reports/export?report=products&period=${preset}`}>
+        <DownloadIcon className="mr-1.5 size-4" />
+        Stiahnuť CSV
+      </a>
+    </Button>
+  );
+}
 
+export default function ProductProfitabilityPage({ searchParams }: Props) {
+  // Middleware guards /admin/*; the CSV export route enforces requireReportsView.
   return (
     <>
       <AdminHeader
@@ -112,22 +119,19 @@ export default async function ProductProfitabilityPage({
       />
       <section className="@container/page space-y-4 p-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <PeriodPicker basePath="/admin/reports/profitability/products" />
-          <Button asChild size="sm" variant="outline">
-            <a
-              href={`/api/admin/reports/export?report=products&period=${preset}`}
-            >
-              <DownloadIcon className="mr-1.5 size-4" />
-              Stiahnuť CSV
-            </a>
-          </Button>
+          <Suspense fallback={<div className="h-9 w-48" />}>
+            <PeriodPicker basePath="/admin/reports/profitability/products" />
+          </Suspense>
+          <Suspense fallback={null}>
+            <ExportButton searchParams={searchParams} />
+          </Suspense>
         </div>
         <Suspense
           fallback={
             <div className="h-64 animate-pulse rounded-lg bg-muted/40" />
           }
         >
-          <ProductReport searchParams={Promise.resolve(params)} />
+          <ProductReport searchParams={searchParams} />
         </Suspense>
       </section>
     </>

--- a/src/app/(admin)/admin/reports/profitability/stores/page.tsx
+++ b/src/app/(admin)/admin/reports/profitability/stores/page.tsx
@@ -13,7 +13,6 @@ import {
   marginColor,
 } from "@/features/reports/lib/format";
 import { resolvePeriod } from "@/features/reports/lib/period";
-import { requireReportsView } from "@/lib/auth/guards";
 import { AdminHeader } from "@/widgets/admin-header/admin-header";
 
 interface Props {
@@ -110,11 +109,21 @@ async function StoreReport({ searchParams }: Props) {
   );
 }
 
-export default async function StoreProfitabilityPage({ searchParams }: Props) {
-  await requireReportsView();
+async function ExportButton({ searchParams }: Props) {
   const params = await searchParams;
   const preset = params.period ?? "30d";
+  return (
+    <Button asChild size="sm" variant="outline">
+      <a href={`/api/admin/reports/export?report=stores&period=${preset}`}>
+        <DownloadIcon className="mr-1.5 size-4" />
+        Stiahnuť CSV
+      </a>
+    </Button>
+  );
+}
 
+export default function StoreProfitabilityPage({ searchParams }: Props) {
+  // Middleware guards /admin/*; the CSV export route enforces requireReportsView.
   return (
     <>
       <AdminHeader
@@ -126,22 +135,19 @@ export default async function StoreProfitabilityPage({ searchParams }: Props) {
       />
       <section className="@container/page space-y-4 p-4">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <PeriodPicker basePath="/admin/reports/profitability/stores" />
-          <Button asChild size="sm" variant="outline">
-            <a
-              href={`/api/admin/reports/export?report=stores&period=${preset}`}
-            >
-              <DownloadIcon className="mr-1.5 size-4" />
-              Stiahnuť CSV
-            </a>
-          </Button>
+          <Suspense fallback={<div className="h-9 w-48" />}>
+            <PeriodPicker basePath="/admin/reports/profitability/stores" />
+          </Suspense>
+          <Suspense fallback={null}>
+            <ExportButton searchParams={searchParams} />
+          </Suspense>
         </div>
         <Suspense
           fallback={
             <div className="h-64 animate-pulse rounded-lg bg-muted/40" />
           }
         >
-          <StoreReport searchParams={Promise.resolve(params)} />
+          <StoreReport searchParams={searchParams} />
         </Suspense>
       </section>
     </>

--- a/src/app/(admin)/admin/reports/profitability/stores/page.tsx
+++ b/src/app/(admin)/admin/reports/profitability/stores/page.tsx
@@ -1,0 +1,149 @@
+import { DownloadIcon } from "lucide-react";
+import { Suspense } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  getProfitabilitySummary,
+  getStoreProfitability,
+} from "@/features/reports/api/queries";
+import { KpiCard } from "@/features/reports/components/kpi-card";
+import { PeriodPicker } from "@/features/reports/components/period-picker";
+import {
+  formatEur,
+  formatPct,
+  marginColor,
+} from "@/features/reports/lib/format";
+import { resolvePeriod } from "@/features/reports/lib/period";
+import { requireReportsView } from "@/lib/auth/guards";
+import { AdminHeader } from "@/widgets/admin-header/admin-header";
+
+interface Props {
+  searchParams: Promise<{ period?: string }>;
+}
+
+async function StoreReport({ searchParams }: Props) {
+  const params = await searchParams;
+  const preset =
+    (params.period as "7d" | "30d" | "90d" | "mtd" | "ytd" | undefined) ??
+    "30d";
+  const period = resolvePeriod(preset);
+
+  const [summary, rows] = await Promise.all([
+    getProfitabilitySummary(period),
+    getStoreProfitability(period),
+  ]);
+
+  return (
+    <>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard label="Tržby" value={formatEur(summary.revenueCents)} />
+        <KpiCard label="Náklady" value={formatEur(summary.costCents)} />
+        <KpiCard label="Marža (€)" value={formatEur(summary.marginCents)} />
+        <KpiCard label="Marža %" value={formatPct(summary.marginPct)} />
+      </div>
+
+      {summary.untrackedShare > 0 && (
+        <p className="rounded-md border border-amber-300 bg-amber-50 p-2 text-amber-700 text-xs dark:border-amber-800 dark:bg-amber-950 dark:text-amber-300">
+          {Math.round(summary.untrackedShare * 100)} % objednávok v období nemá
+          zaznamenané náklady (vytvorené pred zavedením sledovania). Tieto sú
+          vylúčené zo sumy nákladov.
+        </p>
+      )}
+
+      {rows.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+          V zvolenom období neboli žiadne objednávky.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/40 text-left text-muted-foreground text-xs">
+              <tr>
+                <th className="px-3 py-2 font-medium">Predajňa</th>
+                <th className="px-3 py-2 font-medium">Objednávky</th>
+                <th className="px-3 py-2 text-right font-medium">Tržby</th>
+                <th className="px-3 py-2 text-right font-medium">Náklady</th>
+                <th className="px-3 py-2 text-right font-medium">Marža</th>
+                <th className="px-3 py-2 text-right font-medium">Marža %</th>
+                <th className="px-3 py-2 text-right font-medium">
+                  Bez nákladov
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <tr
+                  className="border-b hover:bg-muted/30"
+                  key={r.storeId ?? "no-store"}
+                >
+                  <td className="px-3 py-2 font-medium">
+                    {r.storeName ?? "(bez predajne)"}
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">
+                    {r.orderCount}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums">
+                    {formatEur(r.revenueCents)}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums">
+                    {formatEur(r.costCents)}
+                  </td>
+                  <td className="px-3 py-2 text-right tabular-nums">
+                    {formatEur(r.marginCents)}
+                  </td>
+                  <td
+                    className={`px-3 py-2 text-right tabular-nums ${marginColor(r.marginPct)}`}
+                  >
+                    {formatPct(r.marginPct)}
+                  </td>
+                  <td className="px-3 py-2 text-right text-muted-foreground text-xs">
+                    {r.untrackedCostOrderCount > 0
+                      ? `${r.untrackedCostOrderCount} obj.`
+                      : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default async function StoreProfitabilityPage({ searchParams }: Props) {
+  await requireReportsView();
+  const params = await searchParams;
+  const preset = params.period ?? "30d";
+
+  return (
+    <>
+      <AdminHeader
+        breadcrumbs={[
+          { label: "Dashboard", href: "/admin" },
+          { label: "Reporty", href: "/admin/reports" },
+          { label: "Ziskovosť predajní" },
+        ]}
+      />
+      <section className="@container/page space-y-4 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <PeriodPicker basePath="/admin/reports/profitability/stores" />
+          <Button asChild size="sm" variant="outline">
+            <a
+              href={`/api/admin/reports/export?report=stores&period=${preset}`}
+            >
+              <DownloadIcon className="mr-1.5 size-4" />
+              Stiahnuť CSV
+            </a>
+          </Button>
+        </div>
+        <Suspense
+          fallback={
+            <div className="h-64 animate-pulse rounded-lg bg-muted/40" />
+          }
+        >
+          <StoreReport searchParams={Promise.resolve(params)} />
+        </Suspense>
+      </section>
+    </>
+  );
+}

--- a/src/app/(public)/(pages)/product/[slug]/page.tsx
+++ b/src/app/(public)/(pages)/product/[slug]/page.tsx
@@ -18,7 +18,8 @@ import { buttonVariants } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { getAllergens } from "@/features/allergens/api/queries";
 import { AllergenList } from "@/features/allergens/components/allergen-list";
-import type { AllergenCode } from "@/features/allergens/schema";
+import { NutritionTable } from "@/features/nutrition/components/nutrition-table";
+import { getDerivedProductDisplay } from "@/features/products/api/product-display";
 import { getProducts, type Product } from "@/features/products/api/queries";
 import {
   getPublishedReviews,
@@ -125,6 +126,10 @@ export default async function ProductPage({ params }: Props) {
   if (!result) {
     notFound();
   }
+
+  // Phase D: derive allergens (recipe → ingredients with manual fallback)
+  // and nutrition (override > computed > none) for the consolidated PDP view.
+  const display = await getDerivedProductDisplay(result.id);
 
   const isInStock = result.status === "active";
   const pickupDates = result.category?.pickupDates;
@@ -282,12 +287,22 @@ export default async function ProductPage({ params }: Props) {
             />
           </div>
 
-          {result.allergenCodes.length > 0 && (
+          {display.allergenCodes.length > 0 && (
             <>
               <Separator />
               <AllergenList
                 allergens={allergens}
-                codes={result.allergenCodes as AllergenCode[]}
+                codes={display.allergenCodes}
+              />
+            </>
+          )}
+
+          {display.nutrition && (
+            <>
+              <Separator />
+              <NutritionTable
+                nutrition={display.nutrition}
+                source={display.nutritionSource}
               />
             </>
           )}

--- a/src/app/(public)/(pages)/product/[slug]/page.tsx
+++ b/src/app/(public)/(pages)/product/[slug]/page.tsx
@@ -16,6 +16,9 @@ import { ProductImage } from "@/components/shared/product-image";
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { getAllergens } from "@/features/allergens/api/queries";
+import { AllergenList } from "@/features/allergens/components/allergen-list";
+import type { AllergenCode } from "@/features/allergens/schema";
 import { getProducts, type Product } from "@/features/products/api/queries";
 import {
   getPublishedReviews,
@@ -113,7 +116,10 @@ function getProductRecommendations(
 export default async function ProductPage({ params }: Props) {
   const { slug } = await params;
   const urlDecoded = decodeURIComponent(slug);
-  const products = await getProducts();
+  const [products, allergens] = await Promise.all([
+    getProducts(),
+    getAllergens(),
+  ]);
   const result = products.find((p) => p.slug === urlDecoded) ?? null;
 
   if (!result) {
@@ -275,6 +281,16 @@ export default async function ProductPage({ params }: Props) {
               dangerouslySetInnerHTML={{ __html: descriptionHtml }}
             />
           </div>
+
+          {result.allergenCodes.length > 0 && (
+            <>
+              <Separator />
+              <AllergenList
+                allergens={allergens}
+                codes={result.allergenCodes as AllergenCode[]}
+              />
+            </>
+          )}
 
           <Separator />
 

--- a/src/app/api/admin/reports/export/route.ts
+++ b/src/app/api/admin/reports/export/route.ts
@@ -1,0 +1,53 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  exportProductProfitabilityCsv,
+  exportStoreProfitabilityCsv,
+} from "@/features/reports/api/exports";
+import {
+  formatPeriodForFilename,
+  resolvePeriod,
+} from "@/features/reports/lib/period";
+import { requireReportsView } from "@/lib/auth/guards";
+import { log } from "@/lib/logger";
+
+const VALID_PRESETS = new Set(["7d", "30d", "90d", "mtd", "ytd", "custom"]);
+
+export async function GET(req: NextRequest) {
+  await requireReportsView();
+
+  const url = new URL(req.url);
+  const report = url.searchParams.get("report");
+  const presetRaw = url.searchParams.get("period") ?? "30d";
+  const preset = (VALID_PRESETS.has(presetRaw) ? presetRaw : "30d") as
+    | "7d"
+    | "30d"
+    | "90d"
+    | "mtd"
+    | "ytd"
+    | "custom";
+
+  if (report !== "stores" && report !== "products") {
+    return NextResponse.json({ error: "Unknown report" }, { status: 400 });
+  }
+
+  const period = resolvePeriod(preset);
+
+  try {
+    const csv =
+      report === "stores"
+        ? await exportStoreProfitabilityCsv(period)
+        : await exportProductProfitabilityCsv(period);
+    const filename = `reporty-${report === "stores" ? "predajne" : "produkty"}-${formatPeriodForFilename(period)}.csv`;
+
+    return new NextResponse(csv, {
+      headers: {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (err) {
+    log.reports.error({ err, report, preset }, "CSV export failed");
+    return NextResponse.json({ error: "Export failed" }, { status: 500 });
+  }
+}

--- a/src/components/sheets/edit-product-sheet.tsx
+++ b/src/components/sheets/edit-product-sheet.tsx
@@ -16,6 +16,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Spinner } from "@/components/ui/spinner";
+import type { Allergen } from "@/features/allergens/api/queries";
 import type { Category } from "@/features/categories/api/queries";
 import type { AdminProduct } from "@/features/products/api/queries";
 import { useProductParams } from "@/hooks/use-product-params";
@@ -24,9 +25,11 @@ import { cn } from "@/lib/utils";
 export function EditProductSheet({
   product,
   categories,
+  allergens,
 }: {
   product: AdminProduct;
   categories: Category[];
+  allergens: Allergen[];
 }) {
   const { productId, setParams } = useProductParams();
 
@@ -48,6 +51,7 @@ export function EditProductSheet({
 
         <div className="flex flex-1 flex-col overflow-y-auto">
           <ProductForm
+            allergens={allergens}
             categories={categories}
             className=""
             formId={formId}

--- a/src/db/migrations/0007_nasty_leader.sql
+++ b/src/db/migrations/0007_nasty_leader.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "order_items" ADD COLUMN "unit_cost_cents" integer;--> statement-breakpoint
+ALTER TABLE "order_items" ADD CONSTRAINT "order_items_unit_cost_non_negative" CHECK ("order_items"."unit_cost_cents" IS NULL OR "order_items"."unit_cost_cents" >= 0);

--- a/src/db/migrations/0008_certain_ezekiel_stane.sql
+++ b/src/db/migrations/0008_certain_ezekiel_stane.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "allergens" (
+	"code" text PRIMARY KEY NOT NULL,
+	"name_sk" text NOT NULL,
+	"name_en" text NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "products" ADD COLUMN "allergen_codes" text[] DEFAULT ARRAY[]::text[] NOT NULL;--> statement-breakpoint
+INSERT INTO "allergens" ("code", "name_sk", "name_en", "sort_order") VALUES
+  ('gluten',      'Lepok',                       'Gluten',       10),
+  ('crustaceans', 'Kôrovce',                     'Crustaceans',  20),
+  ('eggs',        'Vajcia',                      'Eggs',         30),
+  ('fish',        'Ryby',                        'Fish',         40),
+  ('peanuts',     'Arašidy',                     'Peanuts',      50),
+  ('soybeans',    'Sójové bôby',                 'Soybeans',     60),
+  ('milk',        'Mlieko',                      'Milk',         70),
+  ('tree_nuts',   'Orechy',                      'Tree nuts',    80),
+  ('celery',      'Zeler',                       'Celery',       90),
+  ('mustard',     'Horčica',                     'Mustard',     100),
+  ('sesame',      'Sezam',                       'Sesame',      110),
+  ('sulphites',   'Oxid siričitý a siričitany',  'Sulphites',   120),
+  ('lupin',       'Vlčí bôb',                    'Lupin',       130),
+  ('molluscs',    'Mäkkýše',                     'Molluscs',    140);

--- a/src/db/migrations/0009_curved_firebrand.sql
+++ b/src/db/migrations/0009_curved_firebrand.sql
@@ -1,0 +1,124 @@
+-- Extensions used by the fuzzy/duplicate-detection ingredient queries
+CREATE EXTENSION IF NOT EXISTS pg_trgm;--> statement-breakpoint
+CREATE EXTENSION IF NOT EXISTS unaccent;--> statement-breakpoint
+-- unaccent() is STABLE by default which blocks index usage; wrap in IMMUTABLE.
+CREATE OR REPLACE FUNCTION public.f_unaccent(text)
+  RETURNS text
+  LANGUAGE sql
+  IMMUTABLE PARALLEL SAFE STRICT
+AS $$ SELECT public.unaccent('public.unaccent', $1) $$;--> statement-breakpoint
+CREATE TABLE "ingredient_price_history" (
+	"id" text PRIMARY KEY NOT NULL,
+	"ingredient_id" text NOT NULL,
+	"price_per_kg_cents" integer,
+	"price_per_piece_cents" integer,
+	"supplier_name" text,
+	"source" text DEFAULT 'manual' NOT NULL,
+	"notes" text,
+	"effective_from" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "iph_price_kg_non_negative" CHECK ("ingredient_price_history"."price_per_kg_cents"    IS NULL OR "ingredient_price_history"."price_per_kg_cents"    >= 0),
+	CONSTRAINT "iph_price_piece_non_negative" CHECK ("ingredient_price_history"."price_per_piece_cents" IS NULL OR "ingredient_price_history"."price_per_piece_cents" >= 0),
+	CONSTRAINT "iph_price_xor" CHECK (("ingredient_price_history"."price_per_kg_cents"    IS NOT NULL AND "ingredient_price_history"."price_per_piece_cents" IS NULL)
+       OR ("ingredient_price_history"."price_per_piece_cents" IS NOT NULL AND "ingredient_price_history"."price_per_kg_cents"    IS NULL))
+);
+--> statement-breakpoint
+CREATE TABLE "ingredients" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text DEFAULT 'Nová surovina' NOT NULL,
+	"slug" text NOT NULL,
+	"base_unit" text DEFAULT 'g' NOT NULL,
+	"grams_per_piece" integer,
+	"price_per_kg_cents" integer,
+	"price_per_piece_cents" integer,
+	"supplier_name" text,
+	"allergen_codes" text[] DEFAULT ARRAY[]::text[] NOT NULL,
+	"nutrition_per_100" jsonb,
+	"nutrition_source" text DEFAULT 'manual' NOT NULL,
+	"notes" text,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "ingredients_slug_unique" UNIQUE("slug"),
+	CONSTRAINT "ingredients_price_kg_non_negative" CHECK ("ingredients"."price_per_kg_cents" IS NULL OR "ingredients"."price_per_kg_cents" >= 0),
+	CONSTRAINT "ingredients_price_piece_non_negative" CHECK ("ingredients"."price_per_piece_cents" IS NULL OR "ingredients"."price_per_piece_cents" >= 0),
+	CONSTRAINT "ingredients_grams_per_piece_when_piece" CHECK (("ingredients"."base_unit" <> 'piece') OR ("ingredients"."grams_per_piece" IS NOT NULL AND "ingredients"."grams_per_piece" > 0)),
+	CONSTRAINT "ingredients_price_matches_base_unit" CHECK (("ingredients"."base_unit" = 'g'     AND "ingredients"."price_per_kg_cents"    IS NOT NULL AND "ingredients"."price_per_piece_cents" IS NULL)
+       OR ("ingredients"."base_unit" = 'piece' AND "ingredients"."price_per_piece_cents" IS NOT NULL AND "ingredients"."price_per_kg_cents"    IS NULL))
+);
+--> statement-breakpoint
+ALTER TABLE "ingredient_price_history" ADD CONSTRAINT "ingredient_price_history_ingredient_id_ingredients_id_fk" FOREIGN KEY ("ingredient_id") REFERENCES "public"."ingredients"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_iph_ingredient_effective" ON "ingredient_price_history" USING btree ("ingredient_id","effective_from");--> statement-breakpoint
+CREATE INDEX "idx_ingredients_slug" ON "ingredients" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "idx_ingredients_active" ON "ingredients" USING btree ("is_active");--> statement-breakpoint
+-- Trigram GIN index for fuzzy/duplicate-suggestion queries (Phase B).
+-- Drizzle's index DSL can't express gin_trgm_ops cleanly; raw SQL here.
+CREATE INDEX "idx_ingredients_name_trgm" ON "ingredients" USING gin (lower(f_unaccent("name")) gin_trgm_ops);--> statement-breakpoint
+-- Seed: ~50 bakery ingredients. Names + allergens + base unit only.
+-- Prices placeholder (0) and nutrition NULL — admin fills via the UI / AI autofill.
+INSERT INTO "ingredients" ("id","name","slug","base_unit","grams_per_piece","price_per_kg_cents","price_per_piece_cents","allergen_codes","nutrition_source","notes") VALUES
+  -- Múky
+  ('ing_seed_muka_t550','Hladká múka T550','muka-t550','g',NULL,0,NULL,ARRAY['gluten'],'seed','Cena: doplniť'),
+  ('ing_seed_muka_t650','Hladká múka T650','muka-t650','g',NULL,0,NULL,ARRAY['gluten'],'seed','Cena: doplniť'),
+  ('ing_seed_muka_t1050','Polohrubá múka T1050','muka-t1050','g',NULL,0,NULL,ARRAY['gluten'],'seed','Cena: doplniť'),
+  ('ing_seed_muka_t1800','Hrubá múka T1800','muka-t1800','g',NULL,0,NULL,ARRAY['gluten'],'seed','Cena: doplniť'),
+  ('ing_seed_muka_spaldova','Špaldová múka','muka-spaldova','g',NULL,0,NULL,ARRAY['gluten'],'seed','Cena: doplniť'),
+  ('ing_seed_muka_razna_tmava','Ražná múka tmavá','muka-razna-tmava','g',NULL,0,NULL,ARRAY['gluten'],'seed','Cena: doplniť'),
+  ('ing_seed_muka_razna_svetla','Ražná múka svetlá','muka-razna-svetla','g',NULL,0,NULL,ARRAY['gluten'],'seed','Cena: doplniť'),
+  ('ing_seed_muka_kukuricna','Kukuričná múka','muka-kukuricna','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  -- Tekutiny / mlieko
+  ('ing_seed_voda','Voda','voda','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_mlieko_1_5','Mlieko 1,5 %','mlieko-1-5','g',NULL,0,NULL,ARRAY['milk'],'seed','Cena: doplniť'),
+  ('ing_seed_mlieko_3_5','Mlieko 3,5 %','mlieko-3-5','g',NULL,0,NULL,ARRAY['milk'],'seed','Cena: doplniť'),
+  ('ing_seed_smotana_33','Smotana 33 %','smotana-33','g',NULL,0,NULL,ARRAY['milk'],'seed','Cena: doplniť'),
+  ('ing_seed_kysla_smotana','Kyslá smotana','kysla-smotana','g',NULL,0,NULL,ARRAY['milk'],'seed','Cena: doplniť'),
+  ('ing_seed_cmar','Cmar','cmar','g',NULL,0,NULL,ARRAY['milk'],'seed','Cena: doplniť'),
+  -- Cukry / sladidlá
+  ('ing_seed_kristal_cukor','Kryštálový cukor','kristal-cukor','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_prasok_cukor','Práškový cukor','praskovy-cukor','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_hnedy_cukor','Hnedý cukor','hnedy-cukor','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_med','Med','med','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_glukozovy_sirup','Glukózový sirup','glukozovy-sirup','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  -- Tuky
+  ('ing_seed_maslo','Maslo','maslo','g',NULL,0,NULL,ARRAY['milk'],'seed','Cena: doplniť'),
+  ('ing_seed_sadlo','Sadlo','sadlo','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_slnecnicovy_olej','Slnečnicový olej','slnecnicovy-olej','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_olivovy_olej','Olivový olej','olivovy-olej','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_repkovy_olej','Repkový olej','repkovy-olej','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  -- Vajcia (piece-based)
+  ('ing_seed_vajce_m','Vajce M','vajce-m','piece',50,NULL,0,ARRAY['eggs'],'seed','Cena: doplniť'),
+  -- Soli / koreniny
+  ('ing_seed_morska_sol','Morská soľ','morska-sol','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_jemna_sol','Jemná soľ','jemna-sol','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_mleta_rasca','Mletá rasca','mleta-rasca','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_mlety_zazvor','Mletý zázvor','mlety-zazvor','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_vanilkovy_cukor','Vanilkový cukor','vanilkovy-cukor','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  -- Kysniace
+  ('ing_seed_cerstve_drozdie','Čerstvé droždie','cerstve-drozdie','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_susene_drozdie','Sušené droždie','susene-drozdie','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_prasok_pecivo','Prášok do pečiva','prasok-do-peciva','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_soda_bikarbona','Sóda bikarbóna','soda-bikarbona','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  -- Orechy / semienka
+  ('ing_seed_vlasske_orechy','Vlašské orechy','vlasske-orechy','g',NULL,0,NULL,ARRAY['tree_nuts'],'seed','Cena: doplniť'),
+  ('ing_seed_mandle','Mandle','mandle','g',NULL,0,NULL,ARRAY['tree_nuts'],'seed','Cena: doplniť'),
+  ('ing_seed_lieskovce','Lieskovce','lieskovce','g',NULL,0,NULL,ARRAY['tree_nuts'],'seed','Cena: doplniť'),
+  ('ing_seed_slnecnicove_seminka','Slnečnicové semienka','slnecnicove-semienka','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_sezamove_seminka','Sezamové semienka','sezamove-semienka','g',NULL,0,NULL,ARRAY['sesame'],'seed','Cena: doplniť'),
+  ('ing_seed_lanove_seminka','Ľanové semienka','lanove-semienka','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_makove_seminka','Makové semienka','makove-semienka','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_tekvicove_seminka','Tekvicové semienka','tekvicove-semienka','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  -- Sušené ovocie
+  ('ing_seed_hrozienka','Hrozienka','hrozienka','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_susene_brusnice','Sušené brusnice','susene-brusnice','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_susene_marhule','Sušené marhule','susene-marhule','g',NULL,0,NULL,ARRAY['sulphites'],'seed','Cena: doplniť'),
+  ('ing_seed_susene_slivky','Sušené slivky','susene-slivky','g',NULL,0,NULL,ARRAY['sulphites'],'seed','Cena: doplniť'),
+  -- Špeciality
+  ('ing_seed_kakao_prasok','Kakaový prášok','kakaovy-prasok','g',NULL,0,NULL,ARRAY[]::text[],'seed','Cena: doplniť'),
+  ('ing_seed_cokolada_70','Čokoláda 70 %','cokolada-70','g',NULL,0,NULL,ARRAY['milk','soybeans'],'seed','Cena: doplniť'),
+  ('ing_seed_mascarpone','Mascarpone','mascarpone','g',NULL,0,NULL,ARRAY['milk'],'seed','Cena: doplniť'),
+  ('ing_seed_syr_niva','Syr Niva','syr-niva','g',NULL,0,NULL,ARRAY['milk'],'seed','Cena: doplniť');
+--> statement-breakpoint
+-- Mirror price-history rows for every seeded ingredient.
+INSERT INTO "ingredient_price_history" ("id","ingredient_id","price_per_kg_cents","price_per_piece_cents","source","notes")
+SELECT 'iph_seed_' || substring(i.id from 10), i.id, i.price_per_kg_cents, i.price_per_piece_cents, 'seed', 'Seed price (zero placeholder)'
+FROM "ingredients" i
+WHERE i.nutrition_source = 'seed';

--- a/src/db/migrations/0010_smart_franklin_storm.sql
+++ b/src/db/migrations/0010_smart_franklin_storm.sql
@@ -1,0 +1,44 @@
+CREATE TABLE "recipe_items" (
+	"id" text PRIMARY KEY NOT NULL,
+	"recipe_id" text NOT NULL,
+	"ingredient_id" text,
+	"sub_recipe_id" text,
+	"quantity_base_unit" integer NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	"notes" text,
+	CONSTRAINT "recipe_items_unique_ingredient" UNIQUE("recipe_id","ingredient_id"),
+	CONSTRAINT "recipe_items_unique_subrecipe" UNIQUE("recipe_id","sub_recipe_id"),
+	CONSTRAINT "recipe_items_xor_ingredient_or_subrecipe" CHECK (("recipe_items"."ingredient_id" IS NOT NULL) <> ("recipe_items"."sub_recipe_id" IS NOT NULL)),
+	CONSTRAINT "recipe_items_quantity_positive" CHECK ("recipe_items"."quantity_base_unit" > 0),
+	CONSTRAINT "recipe_items_no_self_reference" CHECK ("recipe_items"."sub_recipe_id" IS NULL OR "recipe_items"."sub_recipe_id" <> "recipe_items"."recipe_id")
+);
+--> statement-breakpoint
+CREATE TABLE "recipes" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text DEFAULT 'Nový recept' NOT NULL,
+	"slug" text NOT NULL,
+	"kind" text DEFAULT 'product' NOT NULL,
+	"status" text DEFAULT 'draft' NOT NULL,
+	"batch_yield_units" integer DEFAULT 1 NOT NULL,
+	"batch_yield_grams" integer DEFAULT 0 NOT NULL,
+	"yield_loss_percent" integer DEFAULT 10 NOT NULL,
+	"notes" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "recipes_slug_unique" UNIQUE("slug"),
+	CONSTRAINT "recipes_yield_units_positive" CHECK ("recipes"."batch_yield_units" > 0),
+	CONSTRAINT "recipes_yield_grams_non_negative" CHECK ("recipes"."batch_yield_grams" >= 0),
+	CONSTRAINT "recipes_loss_percent_range" CHECK ("recipes"."yield_loss_percent" >= 0 AND "recipes"."yield_loss_percent" <= 50)
+);
+--> statement-breakpoint
+ALTER TABLE "products" ADD COLUMN "recipe_id" text;--> statement-breakpoint
+ALTER TABLE "recipe_items" ADD CONSTRAINT "recipe_items_recipe_id_recipes_id_fk" FOREIGN KEY ("recipe_id") REFERENCES "public"."recipes"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "recipe_items" ADD CONSTRAINT "recipe_items_ingredient_id_ingredients_id_fk" FOREIGN KEY ("ingredient_id") REFERENCES "public"."ingredients"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "recipe_items" ADD CONSTRAINT "recipe_items_sub_recipe_id_recipes_id_fk" FOREIGN KEY ("sub_recipe_id") REFERENCES "public"."recipes"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_recipe_items_recipe_id" ON "recipe_items" USING btree ("recipe_id","sort_order");--> statement-breakpoint
+CREATE INDEX "idx_recipe_items_ingredient_id" ON "recipe_items" USING btree ("ingredient_id");--> statement-breakpoint
+CREATE INDEX "idx_recipe_items_sub_recipe_id" ON "recipe_items" USING btree ("sub_recipe_id");--> statement-breakpoint
+CREATE INDEX "idx_recipes_kind_status" ON "recipes" USING btree ("kind","status");--> statement-breakpoint
+CREATE INDEX "idx_recipes_slug" ON "recipes" USING btree ("slug");--> statement-breakpoint
+ALTER TABLE "products" ADD CONSTRAINT "products_recipe_id_recipes_id_fk" FOREIGN KEY ("recipe_id") REFERENCES "public"."recipes"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "idx_products_recipe_id" ON "products" USING btree ("recipe_id");

--- a/src/db/migrations/0011_rare_spectrum.sql
+++ b/src/db/migrations/0011_rare_spectrum.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "products" ADD COLUMN "nutrition_override" jsonb;

--- a/src/db/migrations/meta/0007_snapshot.json
+++ b/src/db/migrations/meta/0007_snapshot.json
@@ -1,0 +1,3368 @@
+{
+  "id": "7de2c932-ef60-4d3f-862e-6af391f5b52b",
+  "prevId": "c1cfc519-7e2c-4cfe-85a3-3030219f70d7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.b2b_applications": {
+      "name": "b2b_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ico": {
+          "name": "ico",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dic": {
+          "name": "dic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ic_dph": {
+          "name": "ic_dph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_address": {
+          "name": "billing_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_b2b_applications_status": {
+          "name": "idx_b2b_applications_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_b2b_applications_created_at": {
+          "name": "idx_b2b_applications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_b2b_applications_reviewed_at": {
+          "name": "idx_b2b_applications_reviewed_at",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "b2b_applications_reviewed_by_users_id_fk": {
+          "name": "b2b_applications_reviewed_by_users_id_fk",
+          "tableFrom": "b2b_applications",
+          "tableTo": "users",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cart_items": {
+      "name": "cart_items",
+      "schema": "",
+      "columns": {
+        "cart_id": {
+          "name": "cart_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cart_items_cart_id_carts_id_fk": {
+          "name": "cart_items_cart_id_carts_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "carts",
+          "columnsFrom": ["cart_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cart_items_product_id_products_id_fk": {
+          "name": "cart_items_product_id_products_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cart_items_cart_id_product_id_pk": {
+          "name": "cart_items_cart_id_product_id_pk",
+          "columns": ["cart_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.carts": {
+      "name": "carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "carts_user_id_users_id_fk": {
+          "name": "carts_user_id_users_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "carts_company_id_organizations_id_fk": {
+          "name": "carts_company_id_organizations_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "organizations",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "carts_share_token_unique": {
+          "name": "carts_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["share_token"]
+        },
+        "uniq_cart_user_company": {
+          "name": "uniq_cart_user_company",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "company_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová kategória'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Popis vašej kategórie...'"
+        },
+        "show_in_menu": {
+          "name": "show_in_menu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "pickup_dates": {
+          "name": "pickup_dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_b2c": {
+          "name": "show_in_b2c",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_in_b2b": {
+          "name": "show_in_b2b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_sort_order_idx": {
+          "name": "categories_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_slug_idx": {
+          "name": "categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_image_id_media_id_fk": {
+          "name": "categories_image_id_media_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_product_id_products_id_fk": {
+          "name": "favorites_product_id_products_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_user_id_product_id_pk": {
+          "name": "favorites_user_id_product_id_pk",
+          "columns": ["user_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hero_banners": {
+      "name": "hero_banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_label": {
+          "name": "cta_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_href": {
+          "name": "cta_href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hero_banners_active_idx": {
+          "name": "hero_banners_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hero_banners_image_id_media_id_fk": {
+          "name": "hero_banners_image_id_media_id_fk",
+          "tableFrom": "hero_banners",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invoices_org_id": {
+          "name": "idx_invoices_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_due_date": {
+          "name": "idx_invoices_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issued_at": {
+          "name": "idx_invoices_issued_at",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_paid_at": {
+          "name": "idx_invoices_paid_at",
+          "columns": [
+            {
+              "expression": "paid_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_invoice_number": {
+          "name": "idx_invoices_invoice_number",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_org_id_organizations_id_fk": {
+          "name": "invoices_org_id_organizations_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["invoice_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invoices_total_cents_non_negative": {
+          "name": "invoices_total_cents_non_negative",
+          "value": "\"invoices\".\"total_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media_url_unique": {
+          "name": "media_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_items": {
+      "name": "order_items",
+      "schema": "",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_snapshot": {
+          "name": "product_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_cost_cents": {
+          "name": "unit_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "order_items_order_id_product_id_pk": {
+          "name": "order_items_order_id_product_id_pk",
+          "columns": ["order_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_items_price_non_negative": {
+          "name": "order_items_price_non_negative",
+          "value": "\"order_items\".\"price\" >= 0"
+        },
+        "order_items_unit_cost_non_negative": {
+          "name": "order_items_unit_cost_non_negative",
+          "value": "\"order_items\".\"unit_cost_cents\" IS NULL OR \"order_items\".\"unit_cost_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_status_events": {
+      "name": "order_status_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_order_status_event_order_id": {
+          "name": "idx_order_status_event_order_id",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_status_events_order_id_orders_id_fk": {
+          "name": "order_status_events_order_id_orders_id_fk",
+          "tableFrom": "order_status_events",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_status_events_created_by_users_id_fk": {
+          "name": "order_status_events_created_by_users_id_fk",
+          "tableFrom": "order_status_events",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_info": {
+          "name": "customer_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_status": {
+          "name": "order_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_store'"
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_time": {
+          "name": "pickup_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_cents": {
+          "name": "discount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orders_order_number": {
+          "name": "idx_orders_order_number",
+          "columns": [
+            {
+              "expression": "order_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_created_by_store_id": {
+          "name": "idx_created_by_store_id",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_order_status": {
+          "name": "idx_order_status",
+          "columns": [
+            {
+              "expression": "order_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_status": {
+          "name": "idx_payment_status",
+          "columns": [
+            {
+              "expression": "payment_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_method": {
+          "name": "idx_payment_method",
+          "columns": [
+            {
+              "expression": "payment_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pickup_date": {
+          "name": "idx_pickup_date",
+          "columns": [
+            {
+              "expression": "pickup_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_created_at": {
+          "name": "idx_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orders_company_id_idx": {
+          "name": "orders_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "orders_created_by_users_id_fk": {
+          "name": "orders_created_by_users_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_store_id_stores_id_fk": {
+          "name": "orders_store_id_stores_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "stores",
+          "columnsFrom": ["store_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_company_id_organizations_id_fk": {
+          "name": "orders_company_id_organizations_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "organizations",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_invoice_id_invoices_id_fk": {
+          "name": "orders_invoice_id_invoices_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "promo_codes",
+          "columnsFrom": ["promo_code_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["order_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "orders_total_cents_non_negative": {
+          "name": "orders_total_cents_non_negative",
+          "value": "\"orders\".\"total_cents\" >= 0"
+        },
+        "orders_discount_cents_non_negative": {
+          "name": "orders_discount_cents_non_negative",
+          "value": "\"orders\".\"discount_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_tier_id": {
+          "name": "price_tier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_name": {
+          "name": "billing_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ico": {
+          "name": "ico",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dic": {
+          "name": "dic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ic_dph": {
+          "name": "ic_dph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_address": {
+          "name": "billing_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_term_days": {
+          "name": "payment_term_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 14
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_price_tier_id_price_tiers_id_fk": {
+          "name": "organizations_price_tier_id_price_tiers_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "price_tiers",
+          "columnsFrom": ["price_tier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_comments": {
+      "name": "post_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_comments_post_id": {
+          "name": "idx_comments_post_id",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_posts_id_fk": {
+          "name": "post_comments_post_id_posts_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_users_id_fk": {
+          "name": "post_comments_user_id_users_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_parent_id_post_comments_id_fk": {
+          "name": "post_comments_parent_id_post_comments_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "post_comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_likes": {
+      "name": "post_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_post_likes_post_id": {
+          "name": "idx_post_likes_post_id",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_likes_user_id_users_id_fk": {
+          "name": "post_likes_user_id_users_id_fk",
+          "tableFrom": "post_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_likes_post_id_posts_id_fk": {
+          "name": "post_likes_post_id_posts_id_fk",
+          "tableFrom": "post_likes",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_likes_user_id_post_id_pk": {
+          "name": "post_likes_user_id_post_id_pk",
+          "columns": ["user_id", "post_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_tags": {
+      "name": "post_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_tags_name_unique": {
+          "name": "post_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        },
+        "post_tags_slug_unique": {
+          "name": "post_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_to_tags": {
+      "name": "post_to_tags",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_to_tags_post_id_posts_id_fk": {
+          "name": "post_to_tags_post_id_posts_id_fk",
+          "tableFrom": "post_to_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_to_tags_tag_id_post_tags_id_fk": {
+          "name": "post_to_tags_tag_id_post_tags_id_fk",
+          "tableFrom": "post_to_tags",
+          "tableTo": "post_tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_to_tags_post_id_tag_id_pk": {
+          "name": "post_to_tags_post_id_tag_id_pk",
+          "columns": ["post_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nový článok'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes_count": {
+          "name": "likes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comments_count": {
+          "name": "comments_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_posts_slug": {
+          "name": "idx_posts_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_status": {
+          "name": "idx_posts_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_published_at": {
+          "name": "idx_posts_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_cover_image_id_media_id_fk": {
+          "name": "posts_cover_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["cover_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_tiers": {
+      "name": "price_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová cenová skupina'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Popis vašej cenovej skupiny...'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_tier_id": {
+          "name": "price_tier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prices_product_id_products_id_fk": {
+          "name": "prices_product_id_products_id_fk",
+          "tableFrom": "prices",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prices_price_tier_id_price_tiers_id_fk": {
+          "name": "prices_price_tier_id_price_tiers_id_fk",
+          "tableFrom": "prices",
+          "tableTo": "price_tiers",
+          "columnsFrom": ["price_tier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prices_product_id_price_tier_id_pk": {
+          "name": "prices_product_id_price_tier_id_pk",
+          "columns": ["product_id", "price_tier_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prices_price_cents_non_negative": {
+          "name": "prices_price_cents_non_negative",
+          "value": "\"prices\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.product_images": {
+      "name": "product_images",
+      "schema": "",
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_images_media_id_media_id_fk": {
+          "name": "product_images_media_id_media_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_images_product_id_media_id_pk": {
+          "name": "product_images_product_id_media_id_pk",
+          "columns": ["product_id", "media_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nový produkt'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Popis nového produktu...\"}]}]}'::jsonb"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "show_in_b2c": {
+          "name": "show_in_b2c",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_in_b2b": {
+          "name": "show_in_b2b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_category_id": {
+          "name": "idx_products_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_active_status": {
+          "name": "idx_products_active_status",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_sort": {
+          "name": "idx_products_sort",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "products_image_id_media_id_fk": {
+          "name": "products_image_id_media_id_fk",
+          "tableFrom": "products",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "products_price_cents_non_negative": {
+          "name": "products_price_cents_non_negative",
+          "value": "\"products\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.promo_code_usages": {
+      "name": "promo_code_usages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_cents": {
+          "name": "discount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_promo_usage_user": {
+          "name": "idx_promo_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_promo_usage_code": {
+          "name": "idx_promo_usage_code",
+          "columns": [
+            {
+              "expression": "promo_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "promo_code_usages_promo_code_id_promo_codes_id_fk": {
+          "name": "promo_code_usages_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "promo_codes",
+          "columnsFrom": ["promo_code_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promo_code_usages_user_id_users_id_fk": {
+          "name": "promo_code_usages_user_id_users_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "promo_code_usages_order_id_orders_id_fk": {
+          "name": "promo_code_usages_order_id_orders_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.promo_codes": {
+      "name": "promo_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_order_cents": {
+          "name": "min_order_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_usage_count": {
+          "name": "max_usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_usage_per_user": {
+          "name": "max_usage_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "applicable_to_product_ids": {
+          "name": "applicable_to_product_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicable_to_category_ids": {
+          "name": "applicable_to_category_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_promo_codes_code": {
+          "name": "idx_promo_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "promo_codes_value_non_negative": {
+          "name": "promo_codes_value_non_negative",
+          "value": "\"promo_codes\".\"value\" >= 0"
+        },
+        "promo_codes_min_order_cents_non_negative": {
+          "name": "promo_codes_min_order_cents_non_negative",
+          "value": "\"promo_codes\".\"min_order_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product_id": {
+          "name": "idx_reviews_product_id",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_user_id": {
+          "name": "idx_reviews_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_user_product_unique": {
+          "name": "reviews_user_product_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "product_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": ["active_organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_settings": {
+      "name": "site_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stores": {
+      "name": "stores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nova predajňa'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Popis novej predajne...\"}]}]}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"street\":\"\",\"postalCode\":\"\",\"city\":\"\",\"country\":\"\",\"googleId\":\"\"}'::jsonb"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"regularHours\":{\"monday\":\"closed\",\"tuesday\":\"closed\",\"wednesday\":\"closed\",\"thursday\":\"closed\",\"friday\":\"closed\",\"saturday\":\"closed\",\"sunday\":\"closed\"},\"exceptions\":{}}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stores_image_id_media_id_fk": {
+          "name": "stores_image_id_media_id_fk",
+          "tableFrom": "stores",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stores_slug_unique": {
+          "name": "stores_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/0008_snapshot.json
+++ b/src/db/migrations/meta/0008_snapshot.json
@@ -1,0 +1,3413 @@
+{
+  "id": "d794c3d8-36c1-4c8d-9580-f4b23e17b9ea",
+  "prevId": "7de2c932-ef60-4d3f-862e-6af391f5b52b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allergens": {
+      "name": "allergens",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name_sk": {
+          "name": "name_sk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.b2b_applications": {
+      "name": "b2b_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ico": {
+          "name": "ico",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dic": {
+          "name": "dic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ic_dph": {
+          "name": "ic_dph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_address": {
+          "name": "billing_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_b2b_applications_status": {
+          "name": "idx_b2b_applications_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_b2b_applications_created_at": {
+          "name": "idx_b2b_applications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_b2b_applications_reviewed_at": {
+          "name": "idx_b2b_applications_reviewed_at",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "b2b_applications_reviewed_by_users_id_fk": {
+          "name": "b2b_applications_reviewed_by_users_id_fk",
+          "tableFrom": "b2b_applications",
+          "tableTo": "users",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cart_items": {
+      "name": "cart_items",
+      "schema": "",
+      "columns": {
+        "cart_id": {
+          "name": "cart_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cart_items_cart_id_carts_id_fk": {
+          "name": "cart_items_cart_id_carts_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "carts",
+          "columnsFrom": ["cart_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cart_items_product_id_products_id_fk": {
+          "name": "cart_items_product_id_products_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cart_items_cart_id_product_id_pk": {
+          "name": "cart_items_cart_id_product_id_pk",
+          "columns": ["cart_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.carts": {
+      "name": "carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "carts_user_id_users_id_fk": {
+          "name": "carts_user_id_users_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "carts_company_id_organizations_id_fk": {
+          "name": "carts_company_id_organizations_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "organizations",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "carts_share_token_unique": {
+          "name": "carts_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["share_token"]
+        },
+        "uniq_cart_user_company": {
+          "name": "uniq_cart_user_company",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "company_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová kategória'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Popis vašej kategórie...'"
+        },
+        "show_in_menu": {
+          "name": "show_in_menu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "pickup_dates": {
+          "name": "pickup_dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_b2c": {
+          "name": "show_in_b2c",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_in_b2b": {
+          "name": "show_in_b2b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_sort_order_idx": {
+          "name": "categories_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_slug_idx": {
+          "name": "categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_image_id_media_id_fk": {
+          "name": "categories_image_id_media_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_product_id_products_id_fk": {
+          "name": "favorites_product_id_products_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_user_id_product_id_pk": {
+          "name": "favorites_user_id_product_id_pk",
+          "columns": ["user_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hero_banners": {
+      "name": "hero_banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_label": {
+          "name": "cta_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_href": {
+          "name": "cta_href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hero_banners_active_idx": {
+          "name": "hero_banners_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hero_banners_image_id_media_id_fk": {
+          "name": "hero_banners_image_id_media_id_fk",
+          "tableFrom": "hero_banners",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invoices_org_id": {
+          "name": "idx_invoices_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_due_date": {
+          "name": "idx_invoices_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issued_at": {
+          "name": "idx_invoices_issued_at",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_paid_at": {
+          "name": "idx_invoices_paid_at",
+          "columns": [
+            {
+              "expression": "paid_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_invoice_number": {
+          "name": "idx_invoices_invoice_number",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_org_id_organizations_id_fk": {
+          "name": "invoices_org_id_organizations_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["invoice_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invoices_total_cents_non_negative": {
+          "name": "invoices_total_cents_non_negative",
+          "value": "\"invoices\".\"total_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media_url_unique": {
+          "name": "media_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_items": {
+      "name": "order_items",
+      "schema": "",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_snapshot": {
+          "name": "product_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_cost_cents": {
+          "name": "unit_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "order_items_order_id_product_id_pk": {
+          "name": "order_items_order_id_product_id_pk",
+          "columns": ["order_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_items_price_non_negative": {
+          "name": "order_items_price_non_negative",
+          "value": "\"order_items\".\"price\" >= 0"
+        },
+        "order_items_unit_cost_non_negative": {
+          "name": "order_items_unit_cost_non_negative",
+          "value": "\"order_items\".\"unit_cost_cents\" IS NULL OR \"order_items\".\"unit_cost_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_status_events": {
+      "name": "order_status_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_order_status_event_order_id": {
+          "name": "idx_order_status_event_order_id",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_status_events_order_id_orders_id_fk": {
+          "name": "order_status_events_order_id_orders_id_fk",
+          "tableFrom": "order_status_events",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_status_events_created_by_users_id_fk": {
+          "name": "order_status_events_created_by_users_id_fk",
+          "tableFrom": "order_status_events",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_info": {
+          "name": "customer_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_status": {
+          "name": "order_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_store'"
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_time": {
+          "name": "pickup_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_cents": {
+          "name": "discount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orders_order_number": {
+          "name": "idx_orders_order_number",
+          "columns": [
+            {
+              "expression": "order_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_created_by_store_id": {
+          "name": "idx_created_by_store_id",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_order_status": {
+          "name": "idx_order_status",
+          "columns": [
+            {
+              "expression": "order_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_status": {
+          "name": "idx_payment_status",
+          "columns": [
+            {
+              "expression": "payment_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_method": {
+          "name": "idx_payment_method",
+          "columns": [
+            {
+              "expression": "payment_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pickup_date": {
+          "name": "idx_pickup_date",
+          "columns": [
+            {
+              "expression": "pickup_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_created_at": {
+          "name": "idx_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orders_company_id_idx": {
+          "name": "orders_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "orders_created_by_users_id_fk": {
+          "name": "orders_created_by_users_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_store_id_stores_id_fk": {
+          "name": "orders_store_id_stores_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "stores",
+          "columnsFrom": ["store_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_company_id_organizations_id_fk": {
+          "name": "orders_company_id_organizations_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "organizations",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_invoice_id_invoices_id_fk": {
+          "name": "orders_invoice_id_invoices_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "promo_codes",
+          "columnsFrom": ["promo_code_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["order_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "orders_total_cents_non_negative": {
+          "name": "orders_total_cents_non_negative",
+          "value": "\"orders\".\"total_cents\" >= 0"
+        },
+        "orders_discount_cents_non_negative": {
+          "name": "orders_discount_cents_non_negative",
+          "value": "\"orders\".\"discount_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_tier_id": {
+          "name": "price_tier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_name": {
+          "name": "billing_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ico": {
+          "name": "ico",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dic": {
+          "name": "dic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ic_dph": {
+          "name": "ic_dph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_address": {
+          "name": "billing_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_term_days": {
+          "name": "payment_term_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 14
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_price_tier_id_price_tiers_id_fk": {
+          "name": "organizations_price_tier_id_price_tiers_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "price_tiers",
+          "columnsFrom": ["price_tier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_comments": {
+      "name": "post_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_comments_post_id": {
+          "name": "idx_comments_post_id",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_posts_id_fk": {
+          "name": "post_comments_post_id_posts_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_users_id_fk": {
+          "name": "post_comments_user_id_users_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_parent_id_post_comments_id_fk": {
+          "name": "post_comments_parent_id_post_comments_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "post_comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_likes": {
+      "name": "post_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_post_likes_post_id": {
+          "name": "idx_post_likes_post_id",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_likes_user_id_users_id_fk": {
+          "name": "post_likes_user_id_users_id_fk",
+          "tableFrom": "post_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_likes_post_id_posts_id_fk": {
+          "name": "post_likes_post_id_posts_id_fk",
+          "tableFrom": "post_likes",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_likes_user_id_post_id_pk": {
+          "name": "post_likes_user_id_post_id_pk",
+          "columns": ["user_id", "post_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_tags": {
+      "name": "post_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_tags_name_unique": {
+          "name": "post_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        },
+        "post_tags_slug_unique": {
+          "name": "post_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_to_tags": {
+      "name": "post_to_tags",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_to_tags_post_id_posts_id_fk": {
+          "name": "post_to_tags_post_id_posts_id_fk",
+          "tableFrom": "post_to_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_to_tags_tag_id_post_tags_id_fk": {
+          "name": "post_to_tags_tag_id_post_tags_id_fk",
+          "tableFrom": "post_to_tags",
+          "tableTo": "post_tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_to_tags_post_id_tag_id_pk": {
+          "name": "post_to_tags_post_id_tag_id_pk",
+          "columns": ["post_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nový článok'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes_count": {
+          "name": "likes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comments_count": {
+          "name": "comments_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_posts_slug": {
+          "name": "idx_posts_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_status": {
+          "name": "idx_posts_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_published_at": {
+          "name": "idx_posts_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_cover_image_id_media_id_fk": {
+          "name": "posts_cover_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["cover_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_tiers": {
+      "name": "price_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová cenová skupina'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Popis vašej cenovej skupiny...'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_tier_id": {
+          "name": "price_tier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prices_product_id_products_id_fk": {
+          "name": "prices_product_id_products_id_fk",
+          "tableFrom": "prices",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prices_price_tier_id_price_tiers_id_fk": {
+          "name": "prices_price_tier_id_price_tiers_id_fk",
+          "tableFrom": "prices",
+          "tableTo": "price_tiers",
+          "columnsFrom": ["price_tier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prices_product_id_price_tier_id_pk": {
+          "name": "prices_product_id_price_tier_id_pk",
+          "columns": ["product_id", "price_tier_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prices_price_cents_non_negative": {
+          "name": "prices_price_cents_non_negative",
+          "value": "\"prices\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.product_images": {
+      "name": "product_images",
+      "schema": "",
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_images_media_id_media_id_fk": {
+          "name": "product_images_media_id_media_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_images_product_id_media_id_pk": {
+          "name": "product_images_product_id_media_id_pk",
+          "columns": ["product_id", "media_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nový produkt'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Popis nového produktu...\"}]}]}'::jsonb"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "show_in_b2c": {
+          "name": "show_in_b2c",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_in_b2b": {
+          "name": "show_in_b2b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allergen_codes": {
+          "name": "allergen_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_category_id": {
+          "name": "idx_products_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_active_status": {
+          "name": "idx_products_active_status",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_sort": {
+          "name": "idx_products_sort",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "products_image_id_media_id_fk": {
+          "name": "products_image_id_media_id_fk",
+          "tableFrom": "products",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "products_price_cents_non_negative": {
+          "name": "products_price_cents_non_negative",
+          "value": "\"products\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.promo_code_usages": {
+      "name": "promo_code_usages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_cents": {
+          "name": "discount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_promo_usage_user": {
+          "name": "idx_promo_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_promo_usage_code": {
+          "name": "idx_promo_usage_code",
+          "columns": [
+            {
+              "expression": "promo_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "promo_code_usages_promo_code_id_promo_codes_id_fk": {
+          "name": "promo_code_usages_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "promo_codes",
+          "columnsFrom": ["promo_code_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promo_code_usages_user_id_users_id_fk": {
+          "name": "promo_code_usages_user_id_users_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "promo_code_usages_order_id_orders_id_fk": {
+          "name": "promo_code_usages_order_id_orders_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.promo_codes": {
+      "name": "promo_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_order_cents": {
+          "name": "min_order_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_usage_count": {
+          "name": "max_usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_usage_per_user": {
+          "name": "max_usage_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "applicable_to_product_ids": {
+          "name": "applicable_to_product_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicable_to_category_ids": {
+          "name": "applicable_to_category_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_promo_codes_code": {
+          "name": "idx_promo_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "promo_codes_value_non_negative": {
+          "name": "promo_codes_value_non_negative",
+          "value": "\"promo_codes\".\"value\" >= 0"
+        },
+        "promo_codes_min_order_cents_non_negative": {
+          "name": "promo_codes_min_order_cents_non_negative",
+          "value": "\"promo_codes\".\"min_order_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product_id": {
+          "name": "idx_reviews_product_id",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_user_id": {
+          "name": "idx_reviews_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_user_product_unique": {
+          "name": "reviews_user_product_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "product_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": ["active_organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_settings": {
+      "name": "site_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stores": {
+      "name": "stores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nova predajňa'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Popis novej predajne...\"}]}]}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"street\":\"\",\"postalCode\":\"\",\"city\":\"\",\"country\":\"\",\"googleId\":\"\"}'::jsonb"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"regularHours\":{\"monday\":\"closed\",\"tuesday\":\"closed\",\"wednesday\":\"closed\",\"thursday\":\"closed\",\"friday\":\"closed\",\"saturday\":\"closed\",\"sunday\":\"closed\"},\"exceptions\":{}}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stores_image_id_media_id_fk": {
+          "name": "stores_image_id_media_id_fk",
+          "tableFrom": "stores",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stores_slug_unique": {
+          "name": "stores_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/0009_snapshot.json
+++ b/src/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,3685 @@
+{
+  "id": "44174d8f-6383-4ff4-902f-33582e4d7ea2",
+  "prevId": "d794c3d8-36c1-4c8d-9580-f4b23e17b9ea",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allergens": {
+      "name": "allergens",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name_sk": {
+          "name": "name_sk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.b2b_applications": {
+      "name": "b2b_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ico": {
+          "name": "ico",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dic": {
+          "name": "dic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ic_dph": {
+          "name": "ic_dph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_address": {
+          "name": "billing_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_b2b_applications_status": {
+          "name": "idx_b2b_applications_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_b2b_applications_created_at": {
+          "name": "idx_b2b_applications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_b2b_applications_reviewed_at": {
+          "name": "idx_b2b_applications_reviewed_at",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "b2b_applications_reviewed_by_users_id_fk": {
+          "name": "b2b_applications_reviewed_by_users_id_fk",
+          "tableFrom": "b2b_applications",
+          "tableTo": "users",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cart_items": {
+      "name": "cart_items",
+      "schema": "",
+      "columns": {
+        "cart_id": {
+          "name": "cart_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cart_items_cart_id_carts_id_fk": {
+          "name": "cart_items_cart_id_carts_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "carts",
+          "columnsFrom": ["cart_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cart_items_product_id_products_id_fk": {
+          "name": "cart_items_product_id_products_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cart_items_cart_id_product_id_pk": {
+          "name": "cart_items_cart_id_product_id_pk",
+          "columns": ["cart_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.carts": {
+      "name": "carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "carts_user_id_users_id_fk": {
+          "name": "carts_user_id_users_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "carts_company_id_organizations_id_fk": {
+          "name": "carts_company_id_organizations_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "organizations",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "carts_share_token_unique": {
+          "name": "carts_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["share_token"]
+        },
+        "uniq_cart_user_company": {
+          "name": "uniq_cart_user_company",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "company_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová kategória'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Popis vašej kategórie...'"
+        },
+        "show_in_menu": {
+          "name": "show_in_menu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "pickup_dates": {
+          "name": "pickup_dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_b2c": {
+          "name": "show_in_b2c",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_in_b2b": {
+          "name": "show_in_b2b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_sort_order_idx": {
+          "name": "categories_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_slug_idx": {
+          "name": "categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_image_id_media_id_fk": {
+          "name": "categories_image_id_media_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_product_id_products_id_fk": {
+          "name": "favorites_product_id_products_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_user_id_product_id_pk": {
+          "name": "favorites_user_id_product_id_pk",
+          "columns": ["user_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hero_banners": {
+      "name": "hero_banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_label": {
+          "name": "cta_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_href": {
+          "name": "cta_href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hero_banners_active_idx": {
+          "name": "hero_banners_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hero_banners_image_id_media_id_fk": {
+          "name": "hero_banners_image_id_media_id_fk",
+          "tableFrom": "hero_banners",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient_price_history": {
+      "name": "ingredient_price_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ingredient_id": {
+          "name": "ingredient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_per_kg_cents": {
+          "name": "price_per_kg_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_piece_cents": {
+          "name": "price_per_piece_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iph_ingredient_effective": {
+          "name": "idx_iph_ingredient_effective",
+          "columns": [
+            {
+              "expression": "ingredient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingredient_price_history_ingredient_id_ingredients_id_fk": {
+          "name": "ingredient_price_history_ingredient_id_ingredients_id_fk",
+          "tableFrom": "ingredient_price_history",
+          "tableTo": "ingredients",
+          "columnsFrom": ["ingredient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "iph_price_kg_non_negative": {
+          "name": "iph_price_kg_non_negative",
+          "value": "\"ingredient_price_history\".\"price_per_kg_cents\"    IS NULL OR \"ingredient_price_history\".\"price_per_kg_cents\"    >= 0"
+        },
+        "iph_price_piece_non_negative": {
+          "name": "iph_price_piece_non_negative",
+          "value": "\"ingredient_price_history\".\"price_per_piece_cents\" IS NULL OR \"ingredient_price_history\".\"price_per_piece_cents\" >= 0"
+        },
+        "iph_price_xor": {
+          "name": "iph_price_xor",
+          "value": "(\"ingredient_price_history\".\"price_per_kg_cents\"    IS NOT NULL AND \"ingredient_price_history\".\"price_per_piece_cents\" IS NULL)\n       OR (\"ingredient_price_history\".\"price_per_piece_cents\" IS NOT NULL AND \"ingredient_price_history\".\"price_per_kg_cents\"    IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingredients": {
+      "name": "ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová surovina'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_unit": {
+          "name": "base_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'g'"
+        },
+        "grams_per_piece": {
+          "name": "grams_per_piece",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_kg_cents": {
+          "name": "price_per_kg_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_piece_cents": {
+          "name": "price_per_piece_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergen_codes": {
+          "name": "allergen_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "nutrition_per_100": {
+          "name": "nutrition_per_100",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nutrition_source": {
+          "name": "nutrition_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ingredients_slug": {
+          "name": "idx_ingredients_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ingredients_active": {
+          "name": "idx_ingredients_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ingredients_slug_unique": {
+          "name": "ingredients_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ingredients_price_kg_non_negative": {
+          "name": "ingredients_price_kg_non_negative",
+          "value": "\"ingredients\".\"price_per_kg_cents\" IS NULL OR \"ingredients\".\"price_per_kg_cents\" >= 0"
+        },
+        "ingredients_price_piece_non_negative": {
+          "name": "ingredients_price_piece_non_negative",
+          "value": "\"ingredients\".\"price_per_piece_cents\" IS NULL OR \"ingredients\".\"price_per_piece_cents\" >= 0"
+        },
+        "ingredients_grams_per_piece_when_piece": {
+          "name": "ingredients_grams_per_piece_when_piece",
+          "value": "(\"ingredients\".\"base_unit\" <> 'piece') OR (\"ingredients\".\"grams_per_piece\" IS NOT NULL AND \"ingredients\".\"grams_per_piece\" > 0)"
+        },
+        "ingredients_price_matches_base_unit": {
+          "name": "ingredients_price_matches_base_unit",
+          "value": "(\"ingredients\".\"base_unit\" = 'g'     AND \"ingredients\".\"price_per_kg_cents\"    IS NOT NULL AND \"ingredients\".\"price_per_piece_cents\" IS NULL)\n       OR (\"ingredients\".\"base_unit\" = 'piece' AND \"ingredients\".\"price_per_piece_cents\" IS NOT NULL AND \"ingredients\".\"price_per_kg_cents\"    IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invoices_org_id": {
+          "name": "idx_invoices_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_due_date": {
+          "name": "idx_invoices_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issued_at": {
+          "name": "idx_invoices_issued_at",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_paid_at": {
+          "name": "idx_invoices_paid_at",
+          "columns": [
+            {
+              "expression": "paid_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_invoice_number": {
+          "name": "idx_invoices_invoice_number",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_org_id_organizations_id_fk": {
+          "name": "invoices_org_id_organizations_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["invoice_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invoices_total_cents_non_negative": {
+          "name": "invoices_total_cents_non_negative",
+          "value": "\"invoices\".\"total_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media_url_unique": {
+          "name": "media_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_items": {
+      "name": "order_items",
+      "schema": "",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_snapshot": {
+          "name": "product_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_cost_cents": {
+          "name": "unit_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "order_items_order_id_product_id_pk": {
+          "name": "order_items_order_id_product_id_pk",
+          "columns": ["order_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_items_price_non_negative": {
+          "name": "order_items_price_non_negative",
+          "value": "\"order_items\".\"price\" >= 0"
+        },
+        "order_items_unit_cost_non_negative": {
+          "name": "order_items_unit_cost_non_negative",
+          "value": "\"order_items\".\"unit_cost_cents\" IS NULL OR \"order_items\".\"unit_cost_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_status_events": {
+      "name": "order_status_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_order_status_event_order_id": {
+          "name": "idx_order_status_event_order_id",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_status_events_order_id_orders_id_fk": {
+          "name": "order_status_events_order_id_orders_id_fk",
+          "tableFrom": "order_status_events",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_status_events_created_by_users_id_fk": {
+          "name": "order_status_events_created_by_users_id_fk",
+          "tableFrom": "order_status_events",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_info": {
+          "name": "customer_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_status": {
+          "name": "order_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_store'"
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_time": {
+          "name": "pickup_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_cents": {
+          "name": "discount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orders_order_number": {
+          "name": "idx_orders_order_number",
+          "columns": [
+            {
+              "expression": "order_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_created_by_store_id": {
+          "name": "idx_created_by_store_id",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_order_status": {
+          "name": "idx_order_status",
+          "columns": [
+            {
+              "expression": "order_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_status": {
+          "name": "idx_payment_status",
+          "columns": [
+            {
+              "expression": "payment_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_method": {
+          "name": "idx_payment_method",
+          "columns": [
+            {
+              "expression": "payment_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pickup_date": {
+          "name": "idx_pickup_date",
+          "columns": [
+            {
+              "expression": "pickup_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_created_at": {
+          "name": "idx_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orders_company_id_idx": {
+          "name": "orders_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "orders_created_by_users_id_fk": {
+          "name": "orders_created_by_users_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_store_id_stores_id_fk": {
+          "name": "orders_store_id_stores_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "stores",
+          "columnsFrom": ["store_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_company_id_organizations_id_fk": {
+          "name": "orders_company_id_organizations_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "organizations",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_invoice_id_invoices_id_fk": {
+          "name": "orders_invoice_id_invoices_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "promo_codes",
+          "columnsFrom": ["promo_code_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["order_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "orders_total_cents_non_negative": {
+          "name": "orders_total_cents_non_negative",
+          "value": "\"orders\".\"total_cents\" >= 0"
+        },
+        "orders_discount_cents_non_negative": {
+          "name": "orders_discount_cents_non_negative",
+          "value": "\"orders\".\"discount_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_tier_id": {
+          "name": "price_tier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_name": {
+          "name": "billing_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ico": {
+          "name": "ico",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dic": {
+          "name": "dic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ic_dph": {
+          "name": "ic_dph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_address": {
+          "name": "billing_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_term_days": {
+          "name": "payment_term_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 14
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_price_tier_id_price_tiers_id_fk": {
+          "name": "organizations_price_tier_id_price_tiers_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "price_tiers",
+          "columnsFrom": ["price_tier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_comments": {
+      "name": "post_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_comments_post_id": {
+          "name": "idx_comments_post_id",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_posts_id_fk": {
+          "name": "post_comments_post_id_posts_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_users_id_fk": {
+          "name": "post_comments_user_id_users_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_parent_id_post_comments_id_fk": {
+          "name": "post_comments_parent_id_post_comments_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "post_comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_likes": {
+      "name": "post_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_post_likes_post_id": {
+          "name": "idx_post_likes_post_id",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_likes_user_id_users_id_fk": {
+          "name": "post_likes_user_id_users_id_fk",
+          "tableFrom": "post_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_likes_post_id_posts_id_fk": {
+          "name": "post_likes_post_id_posts_id_fk",
+          "tableFrom": "post_likes",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_likes_user_id_post_id_pk": {
+          "name": "post_likes_user_id_post_id_pk",
+          "columns": ["user_id", "post_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_tags": {
+      "name": "post_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_tags_name_unique": {
+          "name": "post_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        },
+        "post_tags_slug_unique": {
+          "name": "post_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_to_tags": {
+      "name": "post_to_tags",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_to_tags_post_id_posts_id_fk": {
+          "name": "post_to_tags_post_id_posts_id_fk",
+          "tableFrom": "post_to_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_to_tags_tag_id_post_tags_id_fk": {
+          "name": "post_to_tags_tag_id_post_tags_id_fk",
+          "tableFrom": "post_to_tags",
+          "tableTo": "post_tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_to_tags_post_id_tag_id_pk": {
+          "name": "post_to_tags_post_id_tag_id_pk",
+          "columns": ["post_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nový článok'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes_count": {
+          "name": "likes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comments_count": {
+          "name": "comments_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_posts_slug": {
+          "name": "idx_posts_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_status": {
+          "name": "idx_posts_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_published_at": {
+          "name": "idx_posts_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_cover_image_id_media_id_fk": {
+          "name": "posts_cover_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["cover_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_tiers": {
+      "name": "price_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová cenová skupina'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Popis vašej cenovej skupiny...'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_tier_id": {
+          "name": "price_tier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prices_product_id_products_id_fk": {
+          "name": "prices_product_id_products_id_fk",
+          "tableFrom": "prices",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prices_price_tier_id_price_tiers_id_fk": {
+          "name": "prices_price_tier_id_price_tiers_id_fk",
+          "tableFrom": "prices",
+          "tableTo": "price_tiers",
+          "columnsFrom": ["price_tier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prices_product_id_price_tier_id_pk": {
+          "name": "prices_product_id_price_tier_id_pk",
+          "columns": ["product_id", "price_tier_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prices_price_cents_non_negative": {
+          "name": "prices_price_cents_non_negative",
+          "value": "\"prices\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.product_images": {
+      "name": "product_images",
+      "schema": "",
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_images_media_id_media_id_fk": {
+          "name": "product_images_media_id_media_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_images_product_id_media_id_pk": {
+          "name": "product_images_product_id_media_id_pk",
+          "columns": ["product_id", "media_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nový produkt'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Popis nového produktu...\"}]}]}'::jsonb"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "show_in_b2c": {
+          "name": "show_in_b2c",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_in_b2b": {
+          "name": "show_in_b2b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allergen_codes": {
+          "name": "allergen_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_category_id": {
+          "name": "idx_products_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_active_status": {
+          "name": "idx_products_active_status",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_sort": {
+          "name": "idx_products_sort",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "products_image_id_media_id_fk": {
+          "name": "products_image_id_media_id_fk",
+          "tableFrom": "products",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "products_price_cents_non_negative": {
+          "name": "products_price_cents_non_negative",
+          "value": "\"products\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.promo_code_usages": {
+      "name": "promo_code_usages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_cents": {
+          "name": "discount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_promo_usage_user": {
+          "name": "idx_promo_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_promo_usage_code": {
+          "name": "idx_promo_usage_code",
+          "columns": [
+            {
+              "expression": "promo_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "promo_code_usages_promo_code_id_promo_codes_id_fk": {
+          "name": "promo_code_usages_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "promo_codes",
+          "columnsFrom": ["promo_code_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promo_code_usages_user_id_users_id_fk": {
+          "name": "promo_code_usages_user_id_users_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "promo_code_usages_order_id_orders_id_fk": {
+          "name": "promo_code_usages_order_id_orders_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.promo_codes": {
+      "name": "promo_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_order_cents": {
+          "name": "min_order_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_usage_count": {
+          "name": "max_usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_usage_per_user": {
+          "name": "max_usage_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "applicable_to_product_ids": {
+          "name": "applicable_to_product_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicable_to_category_ids": {
+          "name": "applicable_to_category_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_promo_codes_code": {
+          "name": "idx_promo_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "promo_codes_value_non_negative": {
+          "name": "promo_codes_value_non_negative",
+          "value": "\"promo_codes\".\"value\" >= 0"
+        },
+        "promo_codes_min_order_cents_non_negative": {
+          "name": "promo_codes_min_order_cents_non_negative",
+          "value": "\"promo_codes\".\"min_order_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product_id": {
+          "name": "idx_reviews_product_id",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_user_id": {
+          "name": "idx_reviews_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_user_product_unique": {
+          "name": "reviews_user_product_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "product_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": ["active_organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_settings": {
+      "name": "site_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stores": {
+      "name": "stores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nova predajňa'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Popis novej predajne...\"}]}]}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"street\":\"\",\"postalCode\":\"\",\"city\":\"\",\"country\":\"\",\"googleId\":\"\"}'::jsonb"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"regularHours\":{\"monday\":\"closed\",\"tuesday\":\"closed\",\"wednesday\":\"closed\",\"thursday\":\"closed\",\"friday\":\"closed\",\"saturday\":\"closed\",\"sunday\":\"closed\"},\"exceptions\":{}}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stores_image_id_media_id_fk": {
+          "name": "stores_image_id_media_id_fk",
+          "tableFrom": "stores",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stores_slug_unique": {
+          "name": "stores_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/0010_snapshot.json
+++ b/src/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,3994 @@
+{
+  "id": "df0bfde5-9adc-4f10-b9a7-961d92312826",
+  "prevId": "44174d8f-6383-4ff4-902f-33582e4d7ea2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allergens": {
+      "name": "allergens",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name_sk": {
+          "name": "name_sk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.b2b_applications": {
+      "name": "b2b_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ico": {
+          "name": "ico",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dic": {
+          "name": "dic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ic_dph": {
+          "name": "ic_dph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_address": {
+          "name": "billing_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_b2b_applications_status": {
+          "name": "idx_b2b_applications_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_b2b_applications_created_at": {
+          "name": "idx_b2b_applications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_b2b_applications_reviewed_at": {
+          "name": "idx_b2b_applications_reviewed_at",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "b2b_applications_reviewed_by_users_id_fk": {
+          "name": "b2b_applications_reviewed_by_users_id_fk",
+          "tableFrom": "b2b_applications",
+          "tableTo": "users",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cart_items": {
+      "name": "cart_items",
+      "schema": "",
+      "columns": {
+        "cart_id": {
+          "name": "cart_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cart_items_cart_id_carts_id_fk": {
+          "name": "cart_items_cart_id_carts_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "carts",
+          "columnsFrom": ["cart_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cart_items_product_id_products_id_fk": {
+          "name": "cart_items_product_id_products_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cart_items_cart_id_product_id_pk": {
+          "name": "cart_items_cart_id_product_id_pk",
+          "columns": ["cart_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.carts": {
+      "name": "carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "carts_user_id_users_id_fk": {
+          "name": "carts_user_id_users_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "carts_company_id_organizations_id_fk": {
+          "name": "carts_company_id_organizations_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "organizations",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "carts_share_token_unique": {
+          "name": "carts_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["share_token"]
+        },
+        "uniq_cart_user_company": {
+          "name": "uniq_cart_user_company",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "company_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová kategória'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Popis vašej kategórie...'"
+        },
+        "show_in_menu": {
+          "name": "show_in_menu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "pickup_dates": {
+          "name": "pickup_dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_b2c": {
+          "name": "show_in_b2c",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_in_b2b": {
+          "name": "show_in_b2b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_sort_order_idx": {
+          "name": "categories_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_slug_idx": {
+          "name": "categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_image_id_media_id_fk": {
+          "name": "categories_image_id_media_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_product_id_products_id_fk": {
+          "name": "favorites_product_id_products_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_user_id_product_id_pk": {
+          "name": "favorites_user_id_product_id_pk",
+          "columns": ["user_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hero_banners": {
+      "name": "hero_banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_label": {
+          "name": "cta_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_href": {
+          "name": "cta_href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hero_banners_active_idx": {
+          "name": "hero_banners_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hero_banners_image_id_media_id_fk": {
+          "name": "hero_banners_image_id_media_id_fk",
+          "tableFrom": "hero_banners",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient_price_history": {
+      "name": "ingredient_price_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ingredient_id": {
+          "name": "ingredient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_per_kg_cents": {
+          "name": "price_per_kg_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_piece_cents": {
+          "name": "price_per_piece_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iph_ingredient_effective": {
+          "name": "idx_iph_ingredient_effective",
+          "columns": [
+            {
+              "expression": "ingredient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingredient_price_history_ingredient_id_ingredients_id_fk": {
+          "name": "ingredient_price_history_ingredient_id_ingredients_id_fk",
+          "tableFrom": "ingredient_price_history",
+          "tableTo": "ingredients",
+          "columnsFrom": ["ingredient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "iph_price_kg_non_negative": {
+          "name": "iph_price_kg_non_negative",
+          "value": "\"ingredient_price_history\".\"price_per_kg_cents\"    IS NULL OR \"ingredient_price_history\".\"price_per_kg_cents\"    >= 0"
+        },
+        "iph_price_piece_non_negative": {
+          "name": "iph_price_piece_non_negative",
+          "value": "\"ingredient_price_history\".\"price_per_piece_cents\" IS NULL OR \"ingredient_price_history\".\"price_per_piece_cents\" >= 0"
+        },
+        "iph_price_xor": {
+          "name": "iph_price_xor",
+          "value": "(\"ingredient_price_history\".\"price_per_kg_cents\"    IS NOT NULL AND \"ingredient_price_history\".\"price_per_piece_cents\" IS NULL)\n       OR (\"ingredient_price_history\".\"price_per_piece_cents\" IS NOT NULL AND \"ingredient_price_history\".\"price_per_kg_cents\"    IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingredients": {
+      "name": "ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová surovina'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_unit": {
+          "name": "base_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'g'"
+        },
+        "grams_per_piece": {
+          "name": "grams_per_piece",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_kg_cents": {
+          "name": "price_per_kg_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_piece_cents": {
+          "name": "price_per_piece_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergen_codes": {
+          "name": "allergen_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "nutrition_per_100": {
+          "name": "nutrition_per_100",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nutrition_source": {
+          "name": "nutrition_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ingredients_slug": {
+          "name": "idx_ingredients_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ingredients_active": {
+          "name": "idx_ingredients_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ingredients_slug_unique": {
+          "name": "ingredients_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ingredients_price_kg_non_negative": {
+          "name": "ingredients_price_kg_non_negative",
+          "value": "\"ingredients\".\"price_per_kg_cents\" IS NULL OR \"ingredients\".\"price_per_kg_cents\" >= 0"
+        },
+        "ingredients_price_piece_non_negative": {
+          "name": "ingredients_price_piece_non_negative",
+          "value": "\"ingredients\".\"price_per_piece_cents\" IS NULL OR \"ingredients\".\"price_per_piece_cents\" >= 0"
+        },
+        "ingredients_grams_per_piece_when_piece": {
+          "name": "ingredients_grams_per_piece_when_piece",
+          "value": "(\"ingredients\".\"base_unit\" <> 'piece') OR (\"ingredients\".\"grams_per_piece\" IS NOT NULL AND \"ingredients\".\"grams_per_piece\" > 0)"
+        },
+        "ingredients_price_matches_base_unit": {
+          "name": "ingredients_price_matches_base_unit",
+          "value": "(\"ingredients\".\"base_unit\" = 'g'     AND \"ingredients\".\"price_per_kg_cents\"    IS NOT NULL AND \"ingredients\".\"price_per_piece_cents\" IS NULL)\n       OR (\"ingredients\".\"base_unit\" = 'piece' AND \"ingredients\".\"price_per_piece_cents\" IS NOT NULL AND \"ingredients\".\"price_per_kg_cents\"    IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invoices_org_id": {
+          "name": "idx_invoices_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_due_date": {
+          "name": "idx_invoices_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issued_at": {
+          "name": "idx_invoices_issued_at",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_paid_at": {
+          "name": "idx_invoices_paid_at",
+          "columns": [
+            {
+              "expression": "paid_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_invoice_number": {
+          "name": "idx_invoices_invoice_number",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_org_id_organizations_id_fk": {
+          "name": "invoices_org_id_organizations_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["invoice_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invoices_total_cents_non_negative": {
+          "name": "invoices_total_cents_non_negative",
+          "value": "\"invoices\".\"total_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media_url_unique": {
+          "name": "media_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_items": {
+      "name": "order_items",
+      "schema": "",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_snapshot": {
+          "name": "product_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_cost_cents": {
+          "name": "unit_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "order_items_order_id_product_id_pk": {
+          "name": "order_items_order_id_product_id_pk",
+          "columns": ["order_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_items_price_non_negative": {
+          "name": "order_items_price_non_negative",
+          "value": "\"order_items\".\"price\" >= 0"
+        },
+        "order_items_unit_cost_non_negative": {
+          "name": "order_items_unit_cost_non_negative",
+          "value": "\"order_items\".\"unit_cost_cents\" IS NULL OR \"order_items\".\"unit_cost_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_status_events": {
+      "name": "order_status_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_order_status_event_order_id": {
+          "name": "idx_order_status_event_order_id",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_status_events_order_id_orders_id_fk": {
+          "name": "order_status_events_order_id_orders_id_fk",
+          "tableFrom": "order_status_events",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_status_events_created_by_users_id_fk": {
+          "name": "order_status_events_created_by_users_id_fk",
+          "tableFrom": "order_status_events",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_info": {
+          "name": "customer_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_status": {
+          "name": "order_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_store'"
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_time": {
+          "name": "pickup_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_cents": {
+          "name": "discount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orders_order_number": {
+          "name": "idx_orders_order_number",
+          "columns": [
+            {
+              "expression": "order_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_created_by_store_id": {
+          "name": "idx_created_by_store_id",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_order_status": {
+          "name": "idx_order_status",
+          "columns": [
+            {
+              "expression": "order_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_status": {
+          "name": "idx_payment_status",
+          "columns": [
+            {
+              "expression": "payment_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_method": {
+          "name": "idx_payment_method",
+          "columns": [
+            {
+              "expression": "payment_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pickup_date": {
+          "name": "idx_pickup_date",
+          "columns": [
+            {
+              "expression": "pickup_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_created_at": {
+          "name": "idx_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orders_company_id_idx": {
+          "name": "orders_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "orders_created_by_users_id_fk": {
+          "name": "orders_created_by_users_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_store_id_stores_id_fk": {
+          "name": "orders_store_id_stores_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "stores",
+          "columnsFrom": ["store_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_company_id_organizations_id_fk": {
+          "name": "orders_company_id_organizations_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "organizations",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_invoice_id_invoices_id_fk": {
+          "name": "orders_invoice_id_invoices_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "promo_codes",
+          "columnsFrom": ["promo_code_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["order_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "orders_total_cents_non_negative": {
+          "name": "orders_total_cents_non_negative",
+          "value": "\"orders\".\"total_cents\" >= 0"
+        },
+        "orders_discount_cents_non_negative": {
+          "name": "orders_discount_cents_non_negative",
+          "value": "\"orders\".\"discount_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_tier_id": {
+          "name": "price_tier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_name": {
+          "name": "billing_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ico": {
+          "name": "ico",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dic": {
+          "name": "dic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ic_dph": {
+          "name": "ic_dph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_address": {
+          "name": "billing_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_term_days": {
+          "name": "payment_term_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 14
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_price_tier_id_price_tiers_id_fk": {
+          "name": "organizations_price_tier_id_price_tiers_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "price_tiers",
+          "columnsFrom": ["price_tier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_comments": {
+      "name": "post_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_comments_post_id": {
+          "name": "idx_comments_post_id",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_posts_id_fk": {
+          "name": "post_comments_post_id_posts_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_users_id_fk": {
+          "name": "post_comments_user_id_users_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_parent_id_post_comments_id_fk": {
+          "name": "post_comments_parent_id_post_comments_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "post_comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_likes": {
+      "name": "post_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_post_likes_post_id": {
+          "name": "idx_post_likes_post_id",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_likes_user_id_users_id_fk": {
+          "name": "post_likes_user_id_users_id_fk",
+          "tableFrom": "post_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_likes_post_id_posts_id_fk": {
+          "name": "post_likes_post_id_posts_id_fk",
+          "tableFrom": "post_likes",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_likes_user_id_post_id_pk": {
+          "name": "post_likes_user_id_post_id_pk",
+          "columns": ["user_id", "post_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_tags": {
+      "name": "post_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_tags_name_unique": {
+          "name": "post_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        },
+        "post_tags_slug_unique": {
+          "name": "post_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_to_tags": {
+      "name": "post_to_tags",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_to_tags_post_id_posts_id_fk": {
+          "name": "post_to_tags_post_id_posts_id_fk",
+          "tableFrom": "post_to_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_to_tags_tag_id_post_tags_id_fk": {
+          "name": "post_to_tags_tag_id_post_tags_id_fk",
+          "tableFrom": "post_to_tags",
+          "tableTo": "post_tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_to_tags_post_id_tag_id_pk": {
+          "name": "post_to_tags_post_id_tag_id_pk",
+          "columns": ["post_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nový článok'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes_count": {
+          "name": "likes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comments_count": {
+          "name": "comments_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_posts_slug": {
+          "name": "idx_posts_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_status": {
+          "name": "idx_posts_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_published_at": {
+          "name": "idx_posts_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_cover_image_id_media_id_fk": {
+          "name": "posts_cover_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["cover_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_tiers": {
+      "name": "price_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová cenová skupina'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Popis vašej cenovej skupiny...'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_tier_id": {
+          "name": "price_tier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prices_product_id_products_id_fk": {
+          "name": "prices_product_id_products_id_fk",
+          "tableFrom": "prices",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prices_price_tier_id_price_tiers_id_fk": {
+          "name": "prices_price_tier_id_price_tiers_id_fk",
+          "tableFrom": "prices",
+          "tableTo": "price_tiers",
+          "columnsFrom": ["price_tier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prices_product_id_price_tier_id_pk": {
+          "name": "prices_product_id_price_tier_id_pk",
+          "columns": ["product_id", "price_tier_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prices_price_cents_non_negative": {
+          "name": "prices_price_cents_non_negative",
+          "value": "\"prices\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.product_images": {
+      "name": "product_images",
+      "schema": "",
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_images_media_id_media_id_fk": {
+          "name": "product_images_media_id_media_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_images_product_id_media_id_pk": {
+          "name": "product_images_product_id_media_id_pk",
+          "columns": ["product_id", "media_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nový produkt'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Popis nového produktu...\"}]}]}'::jsonb"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "show_in_b2c": {
+          "name": "show_in_b2c",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_in_b2b": {
+          "name": "show_in_b2b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allergen_codes": {
+          "name": "allergen_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_category_id": {
+          "name": "idx_products_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_active_status": {
+          "name": "idx_products_active_status",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_sort": {
+          "name": "idx_products_sort",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "products_image_id_media_id_fk": {
+          "name": "products_image_id_media_id_fk",
+          "tableFrom": "products",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "products_price_cents_non_negative": {
+          "name": "products_price_cents_non_negative",
+          "value": "\"products\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.promo_code_usages": {
+      "name": "promo_code_usages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_cents": {
+          "name": "discount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_promo_usage_user": {
+          "name": "idx_promo_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_promo_usage_code": {
+          "name": "idx_promo_usage_code",
+          "columns": [
+            {
+              "expression": "promo_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "promo_code_usages_promo_code_id_promo_codes_id_fk": {
+          "name": "promo_code_usages_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "promo_codes",
+          "columnsFrom": ["promo_code_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promo_code_usages_user_id_users_id_fk": {
+          "name": "promo_code_usages_user_id_users_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "promo_code_usages_order_id_orders_id_fk": {
+          "name": "promo_code_usages_order_id_orders_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.promo_codes": {
+      "name": "promo_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_order_cents": {
+          "name": "min_order_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_usage_count": {
+          "name": "max_usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_usage_per_user": {
+          "name": "max_usage_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "applicable_to_product_ids": {
+          "name": "applicable_to_product_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicable_to_category_ids": {
+          "name": "applicable_to_category_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_promo_codes_code": {
+          "name": "idx_promo_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "promo_codes_value_non_negative": {
+          "name": "promo_codes_value_non_negative",
+          "value": "\"promo_codes\".\"value\" >= 0"
+        },
+        "promo_codes_min_order_cents_non_negative": {
+          "name": "promo_codes_min_order_cents_non_negative",
+          "value": "\"promo_codes\".\"min_order_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recipe_items": {
+      "name": "recipe_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_id": {
+          "name": "ingredient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_recipe_id": {
+          "name": "sub_recipe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity_base_unit": {
+          "name": "quantity_base_unit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_recipe_items_recipe_id": {
+          "name": "idx_recipe_items_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipe_items_ingredient_id": {
+          "name": "idx_recipe_items_ingredient_id",
+          "columns": [
+            {
+              "expression": "ingredient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipe_items_sub_recipe_id": {
+          "name": "idx_recipe_items_sub_recipe_id",
+          "columns": [
+            {
+              "expression": "sub_recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_items_recipe_id_recipes_id_fk": {
+          "name": "recipe_items_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_items",
+          "tableTo": "recipes",
+          "columnsFrom": ["recipe_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_items_ingredient_id_ingredients_id_fk": {
+          "name": "recipe_items_ingredient_id_ingredients_id_fk",
+          "tableFrom": "recipe_items",
+          "tableTo": "ingredients",
+          "columnsFrom": ["ingredient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "recipe_items_sub_recipe_id_recipes_id_fk": {
+          "name": "recipe_items_sub_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_items",
+          "tableTo": "recipes",
+          "columnsFrom": ["sub_recipe_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipe_items_unique_ingredient": {
+          "name": "recipe_items_unique_ingredient",
+          "nullsNotDistinct": false,
+          "columns": ["recipe_id", "ingredient_id"]
+        },
+        "recipe_items_unique_subrecipe": {
+          "name": "recipe_items_unique_subrecipe",
+          "nullsNotDistinct": false,
+          "columns": ["recipe_id", "sub_recipe_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "recipe_items_xor_ingredient_or_subrecipe": {
+          "name": "recipe_items_xor_ingredient_or_subrecipe",
+          "value": "(\"recipe_items\".\"ingredient_id\" IS NOT NULL) <> (\"recipe_items\".\"sub_recipe_id\" IS NOT NULL)"
+        },
+        "recipe_items_quantity_positive": {
+          "name": "recipe_items_quantity_positive",
+          "value": "\"recipe_items\".\"quantity_base_unit\" > 0"
+        },
+        "recipe_items_no_self_reference": {
+          "name": "recipe_items_no_self_reference",
+          "value": "\"recipe_items\".\"sub_recipe_id\" IS NULL OR \"recipe_items\".\"sub_recipe_id\" <> \"recipe_items\".\"recipe_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nový recept'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'product'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "batch_yield_units": {
+          "name": "batch_yield_units",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "batch_yield_grams": {
+          "name": "batch_yield_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "yield_loss_percent": {
+          "name": "yield_loss_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_recipes_kind_status": {
+          "name": "idx_recipes_kind_status",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipes_slug": {
+          "name": "idx_recipes_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipes_slug_unique": {
+          "name": "recipes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "recipes_yield_units_positive": {
+          "name": "recipes_yield_units_positive",
+          "value": "\"recipes\".\"batch_yield_units\" > 0"
+        },
+        "recipes_yield_grams_non_negative": {
+          "name": "recipes_yield_grams_non_negative",
+          "value": "\"recipes\".\"batch_yield_grams\" >= 0"
+        },
+        "recipes_loss_percent_range": {
+          "name": "recipes_loss_percent_range",
+          "value": "\"recipes\".\"yield_loss_percent\" >= 0 AND \"recipes\".\"yield_loss_percent\" <= 50"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product_id": {
+          "name": "idx_reviews_product_id",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_user_id": {
+          "name": "idx_reviews_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_user_product_unique": {
+          "name": "reviews_user_product_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "product_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": ["active_organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_settings": {
+      "name": "site_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stores": {
+      "name": "stores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nova predajňa'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Popis novej predajne...\"}]}]}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"street\":\"\",\"postalCode\":\"\",\"city\":\"\",\"country\":\"\",\"googleId\":\"\"}'::jsonb"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"regularHours\":{\"monday\":\"closed\",\"tuesday\":\"closed\",\"wednesday\":\"closed\",\"thursday\":\"closed\",\"friday\":\"closed\",\"saturday\":\"closed\",\"sunday\":\"closed\"},\"exceptions\":{}}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stores_image_id_media_id_fk": {
+          "name": "stores_image_id_media_id_fk",
+          "tableFrom": "stores",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stores_slug_unique": {
+          "name": "stores_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/0011_snapshot.json
+++ b/src/db/migrations/meta/0011_snapshot.json
@@ -1,0 +1,4000 @@
+{
+  "id": "d7822c13-15f9-43d6-8450-5b25955d15ed",
+  "prevId": "df0bfde5-9adc-4f10-b9a7-961d92312826",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allergens": {
+      "name": "allergens",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name_sk": {
+          "name": "name_sk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name_en": {
+          "name": "name_en",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.b2b_applications": {
+      "name": "b2b_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_name": {
+          "name": "company_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ico": {
+          "name": "ico",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dic": {
+          "name": "dic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ic_dph": {
+          "name": "ic_dph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "billing_address": {
+          "name": "billing_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_b2b_applications_status": {
+          "name": "idx_b2b_applications_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_b2b_applications_created_at": {
+          "name": "idx_b2b_applications_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_b2b_applications_reviewed_at": {
+          "name": "idx_b2b_applications_reviewed_at",
+          "columns": [
+            {
+              "expression": "reviewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "b2b_applications_reviewed_by_users_id_fk": {
+          "name": "b2b_applications_reviewed_by_users_id_fk",
+          "tableFrom": "b2b_applications",
+          "tableTo": "users",
+          "columnsFrom": ["reviewed_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cart_items": {
+      "name": "cart_items",
+      "schema": "",
+      "columns": {
+        "cart_id": {
+          "name": "cart_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "cart_items_cart_id_carts_id_fk": {
+          "name": "cart_items_cart_id_carts_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "carts",
+          "columnsFrom": ["cart_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cart_items_product_id_products_id_fk": {
+          "name": "cart_items_product_id_products_id_fk",
+          "tableFrom": "cart_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "cart_items_cart_id_product_id_pk": {
+          "name": "cart_items_cart_id_product_id_pk",
+          "columns": ["cart_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.carts": {
+      "name": "carts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "carts_user_id_users_id_fk": {
+          "name": "carts_user_id_users_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "carts_company_id_organizations_id_fk": {
+          "name": "carts_company_id_organizations_id_fk",
+          "tableFrom": "carts",
+          "tableTo": "organizations",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "carts_share_token_unique": {
+          "name": "carts_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["share_token"]
+        },
+        "uniq_cart_user_company": {
+          "name": "uniq_cart_user_company",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "company_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.categories": {
+      "name": "categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová kategória'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Popis vašej kategórie...'"
+        },
+        "show_in_menu": {
+          "name": "show_in_menu",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "pickup_dates": {
+          "name": "pickup_dates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "show_in_b2c": {
+          "name": "show_in_b2c",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_in_b2b": {
+          "name": "show_in_b2b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_featured": {
+          "name": "is_featured",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "categories_sort_order_idx": {
+          "name": "categories_sort_order_idx",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "categories_slug_idx": {
+          "name": "categories_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "categories_image_id_media_id_fk": {
+          "name": "categories_image_id_media_id_fk",
+          "tableFrom": "categories",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "categories_slug_unique": {
+          "name": "categories_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.favorites": {
+      "name": "favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "favorites_user_id_users_id_fk": {
+          "name": "favorites_user_id_users_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "favorites_product_id_products_id_fk": {
+          "name": "favorites_product_id_products_id_fk",
+          "tableFrom": "favorites",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "favorites_user_id_product_id_pk": {
+          "name": "favorites_user_id_product_id_pk",
+          "columns": ["user_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hero_banners": {
+      "name": "hero_banners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_label": {
+          "name": "cta_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cta_href": {
+          "name": "cta_href",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hero_banners_active_idx": {
+          "name": "hero_banners_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "hero_banners_image_id_media_id_fk": {
+          "name": "hero_banners_image_id_media_id_fk",
+          "tableFrom": "hero_banners",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ingredient_price_history": {
+      "name": "ingredient_price_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ingredient_id": {
+          "name": "ingredient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_per_kg_cents": {
+          "name": "price_per_kg_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_piece_cents": {
+          "name": "price_per_piece_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_iph_ingredient_effective": {
+          "name": "idx_iph_ingredient_effective",
+          "columns": [
+            {
+              "expression": "ingredient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "effective_from",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ingredient_price_history_ingredient_id_ingredients_id_fk": {
+          "name": "ingredient_price_history_ingredient_id_ingredients_id_fk",
+          "tableFrom": "ingredient_price_history",
+          "tableTo": "ingredients",
+          "columnsFrom": ["ingredient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "iph_price_kg_non_negative": {
+          "name": "iph_price_kg_non_negative",
+          "value": "\"ingredient_price_history\".\"price_per_kg_cents\"    IS NULL OR \"ingredient_price_history\".\"price_per_kg_cents\"    >= 0"
+        },
+        "iph_price_piece_non_negative": {
+          "name": "iph_price_piece_non_negative",
+          "value": "\"ingredient_price_history\".\"price_per_piece_cents\" IS NULL OR \"ingredient_price_history\".\"price_per_piece_cents\" >= 0"
+        },
+        "iph_price_xor": {
+          "name": "iph_price_xor",
+          "value": "(\"ingredient_price_history\".\"price_per_kg_cents\"    IS NOT NULL AND \"ingredient_price_history\".\"price_per_piece_cents\" IS NULL)\n       OR (\"ingredient_price_history\".\"price_per_piece_cents\" IS NOT NULL AND \"ingredient_price_history\".\"price_per_kg_cents\"    IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ingredients": {
+      "name": "ingredients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová surovina'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_unit": {
+          "name": "base_unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'g'"
+        },
+        "grams_per_piece": {
+          "name": "grams_per_piece",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_kg_cents": {
+          "name": "price_per_kg_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_per_piece_cents": {
+          "name": "price_per_piece_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supplier_name": {
+          "name": "supplier_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allergen_codes": {
+          "name": "allergen_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "nutrition_per_100": {
+          "name": "nutrition_per_100",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nutrition_source": {
+          "name": "nutrition_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ingredients_slug": {
+          "name": "idx_ingredients_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ingredients_active": {
+          "name": "idx_ingredients_active",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ingredients_slug_unique": {
+          "name": "ingredients_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ingredients_price_kg_non_negative": {
+          "name": "ingredients_price_kg_non_negative",
+          "value": "\"ingredients\".\"price_per_kg_cents\" IS NULL OR \"ingredients\".\"price_per_kg_cents\" >= 0"
+        },
+        "ingredients_price_piece_non_negative": {
+          "name": "ingredients_price_piece_non_negative",
+          "value": "\"ingredients\".\"price_per_piece_cents\" IS NULL OR \"ingredients\".\"price_per_piece_cents\" >= 0"
+        },
+        "ingredients_grams_per_piece_when_piece": {
+          "name": "ingredients_grams_per_piece_when_piece",
+          "value": "(\"ingredients\".\"base_unit\" <> 'piece') OR (\"ingredients\".\"grams_per_piece\" IS NOT NULL AND \"ingredients\".\"grams_per_piece\" > 0)"
+        },
+        "ingredients_price_matches_base_unit": {
+          "name": "ingredients_price_matches_base_unit",
+          "value": "(\"ingredients\".\"base_unit\" = 'g'     AND \"ingredients\".\"price_per_kg_cents\"    IS NOT NULL AND \"ingredients\".\"price_per_piece_cents\" IS NULL)\n       OR (\"ingredients\".\"base_unit\" = 'piece' AND \"ingredients\".\"price_per_piece_cents\" IS NOT NULL AND \"ingredients\".\"price_per_kg_cents\"    IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_organization_id_organizations_id_fk": {
+          "name": "invitations_organization_id_organizations_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_users_id_fk": {
+          "name": "invitations_inviter_id_users_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "users",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issued_at": {
+          "name": "issued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_invoices_org_id": {
+          "name": "idx_invoices_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_status": {
+          "name": "idx_invoices_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_due_date": {
+          "name": "idx_invoices_due_date",
+          "columns": [
+            {
+              "expression": "due_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_issued_at": {
+          "name": "idx_invoices_issued_at",
+          "columns": [
+            {
+              "expression": "issued_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_paid_at": {
+          "name": "idx_invoices_paid_at",
+          "columns": [
+            {
+              "expression": "paid_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_invoices_invoice_number": {
+          "name": "idx_invoices_invoice_number",
+          "columns": [
+            {
+              "expression": "invoice_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invoices_org_id_organizations_id_fk": {
+          "name": "invoices_org_id_organizations_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["invoice_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invoices_total_cents_non_negative": {
+          "name": "invoices_total_cents_non_negative",
+          "value": "\"invoices\".\"total_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "media_url_unique": {
+          "name": "media_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "members_organization_id_organizations_id_fk": {
+          "name": "members_organization_id_organizations_id_fk",
+          "tableFrom": "members",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "members_user_id_users_id_fk": {
+          "name": "members_user_id_users_id_fk",
+          "tableFrom": "members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.order_items": {
+      "name": "order_items",
+      "schema": "",
+      "columns": {
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_snapshot": {
+          "name": "product_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_cost_cents": {
+          "name": "unit_cost_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "order_items_order_id_orders_id_fk": {
+          "name": "order_items_order_id_orders_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_items_product_id_products_id_fk": {
+          "name": "order_items_product_id_products_id_fk",
+          "tableFrom": "order_items",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "order_items_order_id_product_id_pk": {
+          "name": "order_items_order_id_product_id_pk",
+          "columns": ["order_id", "product_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "order_items_price_non_negative": {
+          "name": "order_items_price_non_negative",
+          "value": "\"order_items\".\"price\" >= 0"
+        },
+        "order_items_unit_cost_non_negative": {
+          "name": "order_items_unit_cost_non_negative",
+          "value": "\"order_items\".\"unit_cost_cents\" IS NULL OR \"order_items\".\"unit_cost_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.order_status_events": {
+      "name": "order_status_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_order_status_event_order_id": {
+          "name": "idx_order_status_event_order_id",
+          "columns": [
+            {
+              "expression": "order_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "order_status_events_order_id_orders_id_fk": {
+          "name": "order_status_events_order_id_orders_id_fk",
+          "tableFrom": "order_status_events",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "order_status_events_created_by_users_id_fk": {
+          "name": "order_status_events_created_by_users_id_fk",
+          "tableFrom": "order_status_events",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "order_number": {
+          "name": "order_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_info": {
+          "name": "customer_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_id": {
+          "name": "store_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivery_address": {
+          "name": "delivery_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_status": {
+          "name": "order_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'in_store'"
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_date": {
+          "name": "pickup_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pickup_time": {
+          "name": "pickup_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_id": {
+          "name": "payment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discount_cents": {
+          "name": "discount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orders_order_number": {
+          "name": "idx_orders_order_number",
+          "columns": [
+            {
+              "expression": "order_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_created_by_store_id": {
+          "name": "idx_created_by_store_id",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "store_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_order_status": {
+          "name": "idx_order_status",
+          "columns": [
+            {
+              "expression": "order_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_status": {
+          "name": "idx_payment_status",
+          "columns": [
+            {
+              "expression": "payment_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_payment_method": {
+          "name": "idx_payment_method",
+          "columns": [
+            {
+              "expression": "payment_method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pickup_date": {
+          "name": "idx_pickup_date",
+          "columns": [
+            {
+              "expression": "pickup_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_created_at": {
+          "name": "idx_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "orders_company_id_idx": {
+          "name": "orders_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "orders_created_by_users_id_fk": {
+          "name": "orders_created_by_users_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_store_id_stores_id_fk": {
+          "name": "orders_store_id_stores_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "stores",
+          "columnsFrom": ["store_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_company_id_organizations_id_fk": {
+          "name": "orders_company_id_organizations_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "organizations",
+          "columnsFrom": ["company_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_invoice_id_invoices_id_fk": {
+          "name": "orders_invoice_id_invoices_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "invoices",
+          "columnsFrom": ["invoice_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "orders_promo_code_id_promo_codes_id_fk": {
+          "name": "orders_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "orders",
+          "tableTo": "promo_codes",
+          "columnsFrom": ["promo_code_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orders_order_number_unique": {
+          "name": "orders_order_number_unique",
+          "nullsNotDistinct": false,
+          "columns": ["order_number"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "orders_total_cents_non_negative": {
+          "name": "orders_total_cents_non_negative",
+          "value": "\"orders\".\"total_cents\" >= 0"
+        },
+        "orders_discount_cents_non_negative": {
+          "name": "orders_discount_cents_non_negative",
+          "value": "\"orders\".\"discount_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_tier_id": {
+          "name": "price_tier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_name": {
+          "name": "billing_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ico": {
+          "name": "ico",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dic": {
+          "name": "dic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ic_dph": {
+          "name": "ic_dph",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_address": {
+          "name": "billing_address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_term_days": {
+          "name": "payment_term_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 14
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_price_tier_id_price_tiers_id_fk": {
+          "name": "organizations_price_tier_id_price_tiers_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "price_tiers",
+          "columnsFrom": ["price_tier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_comments": {
+      "name": "post_comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_comments_post_id": {
+          "name": "idx_comments_post_id",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_comments_post_id_posts_id_fk": {
+          "name": "post_comments_post_id_posts_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_user_id_users_id_fk": {
+          "name": "post_comments_user_id_users_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_comments_parent_id_post_comments_id_fk": {
+          "name": "post_comments_parent_id_post_comments_id_fk",
+          "tableFrom": "post_comments",
+          "tableTo": "post_comments",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_likes": {
+      "name": "post_likes",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_post_likes_post_id": {
+          "name": "idx_post_likes_post_id",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "post_likes_user_id_users_id_fk": {
+          "name": "post_likes_user_id_users_id_fk",
+          "tableFrom": "post_likes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_likes_post_id_posts_id_fk": {
+          "name": "post_likes_post_id_posts_id_fk",
+          "tableFrom": "post_likes",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_likes_user_id_post_id_pk": {
+          "name": "post_likes_user_id_post_id_pk",
+          "columns": ["user_id", "post_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_tags": {
+      "name": "post_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "post_tags_name_unique": {
+          "name": "post_tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        },
+        "post_tags_slug_unique": {
+          "name": "post_tags_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_to_tags": {
+      "name": "post_to_tags",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_to_tags_post_id_posts_id_fk": {
+          "name": "post_to_tags_post_id_posts_id_fk",
+          "tableFrom": "post_to_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_to_tags_tag_id_post_tags_id_fk": {
+          "name": "post_to_tags_tag_id_post_tags_id_fk",
+          "tableFrom": "post_to_tags",
+          "tableTo": "post_tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_to_tags_post_id_tag_id_pk": {
+          "name": "post_to_tags_post_id_tag_id_pk",
+          "columns": ["post_id", "tag_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nový článok'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_image_id": {
+          "name": "cover_image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "likes_count": {
+          "name": "likes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "comments_count": {
+          "name": "comments_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_posts_slug": {
+          "name": "idx_posts_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_status": {
+          "name": "idx_posts_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_posts_published_at": {
+          "name": "idx_posts_published_at",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": ["author_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_cover_image_id_media_id_fk": {
+          "name": "posts_cover_image_id_media_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "media",
+          "columnsFrom": ["cover_image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "posts_slug_unique": {
+          "name": "posts_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.price_tiers": {
+      "name": "price_tiers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nová cenová skupina'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'Popis vašej cenovej skupiny...'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prices": {
+      "name": "prices",
+      "schema": "",
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_tier_id": {
+          "name": "price_tier_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prices_product_id_products_id_fk": {
+          "name": "prices_product_id_products_id_fk",
+          "tableFrom": "prices",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prices_price_tier_id_price_tiers_id_fk": {
+          "name": "prices_price_tier_id_price_tiers_id_fk",
+          "tableFrom": "prices",
+          "tableTo": "price_tiers",
+          "columnsFrom": ["price_tier_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "prices_product_id_price_tier_id_pk": {
+          "name": "prices_product_id_price_tier_id_pk",
+          "columns": ["product_id", "price_tier_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "prices_price_cents_non_negative": {
+          "name": "prices_price_cents_non_negative",
+          "value": "\"prices\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.product_images": {
+      "name": "product_images",
+      "schema": "",
+      "columns": {
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "product_images_product_id_products_id_fk": {
+          "name": "product_images_product_id_products_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "product_images_media_id_media_id_fk": {
+          "name": "product_images_media_id_media_id_fk",
+          "tableFrom": "product_images",
+          "tableTo": "media",
+          "columnsFrom": ["media_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "product_images_product_id_media_id_pk": {
+          "name": "product_images_product_id_media_id_pk",
+          "columns": ["product_id", "media_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.products": {
+      "name": "products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nový produkt'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Popis nového produktu...\"}]}]}'::jsonb"
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "show_in_b2c": {
+          "name": "show_in_b2c",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "show_in_b2b": {
+          "name": "show_in_b2b",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "allergen_codes": {
+          "name": "allergen_codes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::text[]"
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nutrition_override": {
+          "name": "nutrition_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_products_slug": {
+          "name": "idx_products_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_category_id": {
+          "name": "idx_products_category_id",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_active_status": {
+          "name": "idx_products_active_status",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_products_sort": {
+          "name": "idx_products_sort",
+          "columns": [
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "products_category_id_categories_id_fk": {
+          "name": "products_category_id_categories_id_fk",
+          "tableFrom": "products",
+          "tableTo": "categories",
+          "columnsFrom": ["category_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "products_image_id_media_id_fk": {
+          "name": "products_image_id_media_id_fk",
+          "tableFrom": "products",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "products_slug_unique": {
+          "name": "products_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "products_price_cents_non_negative": {
+          "name": "products_price_cents_non_negative",
+          "value": "\"products\".\"price_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.promo_code_usages": {
+      "name": "promo_code_usages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "promo_code_id": {
+          "name": "promo_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_cents": {
+          "name": "discount_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_promo_usage_user": {
+          "name": "idx_promo_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_promo_usage_code": {
+          "name": "idx_promo_usage_code",
+          "columns": [
+            {
+              "expression": "promo_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "promo_code_usages_promo_code_id_promo_codes_id_fk": {
+          "name": "promo_code_usages_promo_code_id_promo_codes_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "promo_codes",
+          "columnsFrom": ["promo_code_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promo_code_usages_user_id_users_id_fk": {
+          "name": "promo_code_usages_user_id_users_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "promo_code_usages_order_id_orders_id_fk": {
+          "name": "promo_code_usages_order_id_orders_id_fk",
+          "tableFrom": "promo_code_usages",
+          "tableTo": "orders",
+          "columnsFrom": ["order_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.promo_codes": {
+      "name": "promo_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "min_order_cents": {
+          "name": "min_order_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_usage_count": {
+          "name": "max_usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "max_usage_per_user": {
+          "name": "max_usage_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "valid_from": {
+          "name": "valid_from",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "valid_until": {
+          "name": "valid_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "applicable_to_product_ids": {
+          "name": "applicable_to_product_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "applicable_to_category_ids": {
+          "name": "applicable_to_category_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_promo_codes_code": {
+          "name": "idx_promo_codes_code",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "promo_codes_code_unique": {
+          "name": "promo_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "promo_codes_value_non_negative": {
+          "name": "promo_codes_value_non_negative",
+          "value": "\"promo_codes\".\"value\" >= 0"
+        },
+        "promo_codes_min_order_cents_non_negative": {
+          "name": "promo_codes_min_order_cents_non_negative",
+          "value": "\"promo_codes\".\"min_order_cents\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recipe_items": {
+      "name": "recipe_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipe_id": {
+          "name": "recipe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ingredient_id": {
+          "name": "ingredient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sub_recipe_id": {
+          "name": "sub_recipe_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quantity_base_unit": {
+          "name": "quantity_base_unit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_recipe_items_recipe_id": {
+          "name": "idx_recipe_items_recipe_id",
+          "columns": [
+            {
+              "expression": "recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipe_items_ingredient_id": {
+          "name": "idx_recipe_items_ingredient_id",
+          "columns": [
+            {
+              "expression": "ingredient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipe_items_sub_recipe_id": {
+          "name": "idx_recipe_items_sub_recipe_id",
+          "columns": [
+            {
+              "expression": "sub_recipe_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recipe_items_recipe_id_recipes_id_fk": {
+          "name": "recipe_items_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_items",
+          "tableTo": "recipes",
+          "columnsFrom": ["recipe_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recipe_items_ingredient_id_ingredients_id_fk": {
+          "name": "recipe_items_ingredient_id_ingredients_id_fk",
+          "tableFrom": "recipe_items",
+          "tableTo": "ingredients",
+          "columnsFrom": ["ingredient_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "recipe_items_sub_recipe_id_recipes_id_fk": {
+          "name": "recipe_items_sub_recipe_id_recipes_id_fk",
+          "tableFrom": "recipe_items",
+          "tableTo": "recipes",
+          "columnsFrom": ["sub_recipe_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipe_items_unique_ingredient": {
+          "name": "recipe_items_unique_ingredient",
+          "nullsNotDistinct": false,
+          "columns": ["recipe_id", "ingredient_id"]
+        },
+        "recipe_items_unique_subrecipe": {
+          "name": "recipe_items_unique_subrecipe",
+          "nullsNotDistinct": false,
+          "columns": ["recipe_id", "sub_recipe_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "recipe_items_xor_ingredient_or_subrecipe": {
+          "name": "recipe_items_xor_ingredient_or_subrecipe",
+          "value": "(\"recipe_items\".\"ingredient_id\" IS NOT NULL) <> (\"recipe_items\".\"sub_recipe_id\" IS NOT NULL)"
+        },
+        "recipe_items_quantity_positive": {
+          "name": "recipe_items_quantity_positive",
+          "value": "\"recipe_items\".\"quantity_base_unit\" > 0"
+        },
+        "recipe_items_no_self_reference": {
+          "name": "recipe_items_no_self_reference",
+          "value": "\"recipe_items\".\"sub_recipe_id\" IS NULL OR \"recipe_items\".\"sub_recipe_id\" <> \"recipe_items\".\"recipe_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.recipes": {
+      "name": "recipes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nový recept'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'product'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "batch_yield_units": {
+          "name": "batch_yield_units",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "batch_yield_grams": {
+          "name": "batch_yield_grams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "yield_loss_percent": {
+          "name": "yield_loss_percent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_recipes_kind_status": {
+          "name": "idx_recipes_kind_status",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_recipes_slug": {
+          "name": "idx_recipes_slug",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recipes_slug_unique": {
+          "name": "recipes_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "recipes_yield_units_positive": {
+          "name": "recipes_yield_units_positive",
+          "value": "\"recipes\".\"batch_yield_units\" > 0"
+        },
+        "recipes_yield_grams_non_negative": {
+          "name": "recipes_yield_grams_non_negative",
+          "value": "\"recipes\".\"batch_yield_grams\" >= 0"
+        },
+        "recipes_loss_percent_range": {
+          "name": "recipes_loss_percent_range",
+          "value": "\"recipes\".\"yield_loss_percent\" >= 0 AND \"recipes\".\"yield_loss_percent\" <= 50"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.reviews": {
+      "name": "reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified_purchase": {
+          "name": "is_verified_purchase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_reviews_product_id": {
+          "name": "idx_reviews_product_id",
+          "columns": [
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_reviews_user_id": {
+          "name": "idx_reviews_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reviews_user_id_users_id_fk": {
+          "name": "reviews_user_id_users_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reviews_product_id_products_id_fk": {
+          "name": "reviews_product_id_products_id_fk",
+          "tableFrom": "reviews",
+          "tableTo": "products",
+          "columnsFrom": ["product_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reviews_user_product_unique": {
+          "name": "reviews_user_product_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "product_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sessions_active_organization_id_organizations_id_fk": {
+          "name": "sessions_active_organization_id_organizations_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "organizations",
+          "columnsFrom": ["active_organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.site_settings": {
+      "name": "site_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stores": {
+      "name": "stores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Nova predajňa'"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Popis novej predajne...\"}]}]}'::jsonb"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"street\":\"\",\"postalCode\":\"\",\"city\":\"\",\"country\":\"\",\"googleId\":\"\"}'::jsonb"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "opening_hours": {
+          "name": "opening_hours",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"regularHours\":{\"monday\":\"closed\",\"tuesday\":\"closed\",\"wednesday\":\"closed\",\"thursday\":\"closed\",\"friday\":\"closed\",\"saturday\":\"closed\",\"sunday\":\"closed\"},\"exceptions\":{}}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "stores_image_id_media_id_fk": {
+          "name": "stores_image_id_media_id_fk",
+          "tableFrom": "stores",
+          "tableTo": "media",
+          "columnsFrom": ["image_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "stores_slug_unique": {
+          "name": "stores_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778656838566,
       "tag": "0010_smart_franklin_storm",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1778661048909,
+      "tag": "0011_rare_spectrum",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1778610510148,
       "tag": "0009_curved_firebrand",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1778656838566,
+      "tag": "0010_smart_franklin_storm",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1778601525106,
       "tag": "0007_nasty_leader",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1778601780354,
+      "tag": "0008_certain_ezekiel_stane",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1778601780354,
       "tag": "0008_certain_ezekiel_stane",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1778610510148,
+      "tag": "0009_curved_firebrand",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1775573863927,
       "tag": "0006_spicy_roughhouse",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1778601525106,
+      "tag": "0007_nasty_leader",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -849,6 +849,13 @@ export const products = pgTable(
       .notNull()
       .default(sql`ARRAY[]::text[]`),
 
+    // Optional FK to a recipe (Phase C). Phase C derives cost from this
+    // recipe at order time; Phase D derives nutrition + allergens.
+    // Nullable: products can ship without a recipe (resold packaged items).
+    // Defined as plain text + manual FK in a separate file to avoid the
+    // circular ref between products and recipes tables.
+    recipeId: text("recipe_id"),
+
     isActive: boolean("is_active").default(true).notNull(),
     sortOrder: integer("sort_order").default(0).notNull(),
     status: text("status").$type<ProductStatus>().default("draft").notNull(),
@@ -899,6 +906,10 @@ export const productsRelations = relations(products, ({ many, one }) => ({
   image: one(media, {
     fields: [products.imageId],
     references: [media.id],
+  }),
+  recipe: one(recipes, {
+    fields: [products.recipeId],
+    references: [recipes.id],
   }),
 }));
 
@@ -1452,3 +1463,124 @@ export const ingredientPriceHistoryRelations = relations(
 );
 
 // #endregion Ingredients
+
+// #region Recipes (Phase C)
+
+export const RECIPE_KINDS = ["product", "sub_recipe"] as const;
+export type RecipeKind = (typeof RECIPE_KINDS)[number];
+
+export const RECIPE_STATUSES = ["draft", "published"] as const;
+export type RecipeStatus = (typeof RECIPE_STATUSES)[number];
+
+/**
+ * Recipe header. Two kinds: 'product' (linked to a product, final SKU)
+ * and 'sub_recipe' (reusable BOM building block — kvások, krém, ...).
+ *
+ * Yield: batch produces N units totalling M grams. Phase D uses
+ * batchYieldGrams + yieldLossPercent to derive finished mass for the
+ * per-100g nutrition table.
+ */
+export const recipes = pgTable(
+  "recipes",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createPrefixedId("rec")),
+    name: text("name").notNull().default("Nový recept"),
+    slug: text("slug")
+      .notNull()
+      .unique()
+      .$defaultFn(() => draftSlug("Nový recept")),
+    kind: text("kind").$type<RecipeKind>().notNull().default("product"),
+    status: text("status").$type<RecipeStatus>().notNull().default("draft"),
+    batchYieldUnits: integer("batch_yield_units").notNull().default(1),
+    batchYieldGrams: integer("batch_yield_grams").notNull().default(0),
+    yieldLossPercent: integer("yield_loss_percent").notNull().default(10),
+    notes: text("notes"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (t) => [
+    index("idx_recipes_kind_status").on(t.kind, t.status),
+    index("idx_recipes_slug").on(t.slug),
+    check("recipes_yield_units_positive", sql`${t.batchYieldUnits} > 0`),
+    check("recipes_yield_grams_non_negative", sql`${t.batchYieldGrams} >= 0`),
+    check(
+      "recipes_loss_percent_range",
+      sql`${t.yieldLossPercent} >= 0 AND ${t.yieldLossPercent} <= 50`
+    ),
+  ]
+);
+
+/**
+ * Recipe BOM. Each row is exactly one of (ingredientId, subRecipeId).
+ * XOR enforced by CHECK; duplicate prevention via unique partial indexes.
+ *
+ * quantityBaseUnit is in the linked ingredient's base unit (g or pieces)
+ * for ingredients, or grams for sub-recipes (consumed by mass).
+ */
+export const recipeItems = pgTable(
+  "recipe_items",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createPrefixedId("rci")),
+    recipeId: text("recipe_id")
+      .notNull()
+      .references(() => recipes.id, { onDelete: "cascade" }),
+    ingredientId: text("ingredient_id").references(() => ingredients.id, {
+      onDelete: "restrict",
+    }),
+    subRecipeId: text("sub_recipe_id").references(() => recipes.id, {
+      onDelete: "restrict",
+    }),
+    quantityBaseUnit: integer("quantity_base_unit").notNull(),
+    sortOrder: integer("sort_order").notNull().default(0),
+    notes: text("notes"),
+  },
+  (t) => [
+    index("idx_recipe_items_recipe_id").on(t.recipeId, t.sortOrder),
+    index("idx_recipe_items_ingredient_id").on(t.ingredientId),
+    index("idx_recipe_items_sub_recipe_id").on(t.subRecipeId),
+    check(
+      "recipe_items_xor_ingredient_or_subrecipe",
+      sql`(${t.ingredientId} IS NOT NULL) <> (${t.subRecipeId} IS NOT NULL)`
+    ),
+    check("recipe_items_quantity_positive", sql`${t.quantityBaseUnit} > 0`),
+    check(
+      "recipe_items_no_self_reference",
+      sql`${t.subRecipeId} IS NULL OR ${t.subRecipeId} <> ${t.recipeId}`
+    ),
+    unique("recipe_items_unique_ingredient").on(t.recipeId, t.ingredientId),
+    unique("recipe_items_unique_subrecipe").on(t.recipeId, t.subRecipeId),
+  ]
+);
+
+export const recipesRelations = relations(recipes, ({ many, one }) => ({
+  items: many(recipeItems, { relationName: "recipe_items" }),
+  product: one(products, {
+    fields: [recipes.id],
+    references: [products.recipeId],
+  }),
+}));
+
+export const recipeItemsRelations = relations(recipeItems, ({ one }) => ({
+  recipe: one(recipes, {
+    fields: [recipeItems.recipeId],
+    references: [recipes.id],
+    relationName: "recipe_items",
+  }),
+  ingredient: one(ingredients, {
+    fields: [recipeItems.ingredientId],
+    references: [ingredients.id],
+  }),
+  subRecipe: one(recipes, {
+    fields: [recipeItems.subRecipeId],
+    references: [recipes.id],
+  }),
+}));
+
+// #endregion Recipes

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -856,6 +856,11 @@ export const products = pgTable(
     // circular ref between products and recipes tables.
     recipeId: text("recipe_id"),
 
+    // Phase D: manual nutrition override. When non-null, PDP shows these
+    // values verbatim and labels them "manuálne". When null, PDP derives
+    // from the recipe (if present) or hides the nutrition section.
+    nutritionOverride: jsonb("nutrition_override"),
+
     isActive: boolean("is_active").default(true).notNull(),
     sortOrder: integer("sort_order").default(0).notNull(),
     status: text("status").$type<ProductStatus>().default("draft").notNull(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -841,6 +841,14 @@ export const products = pgTable(
     showInB2c: boolean("show_in_b2c").default(true).notNull(),
     showInB2b: boolean("show_in_b2b").default(false).notNull(),
 
+    // EU 14-allergen codes manually tagged by admin (Phase A).
+    // In Phase D, products with a recipe derive allergens from ingredients;
+    // this column stays as the fallback for products without a recipe.
+    allergenCodes: text("allergen_codes")
+      .array()
+      .notNull()
+      .default(sql`ARRAY[]::text[]`),
+
     isActive: boolean("is_active").default(true).notNull(),
     sortOrder: integer("sort_order").default(0).notNull(),
     status: text("status").$type<ProductStatus>().default("draft").notNull(),
@@ -1278,3 +1286,21 @@ export const heroBannersRelations = relations(heroBanners, ({ one }) => ({
 }));
 
 // #endregion Hero banners
+
+// #region Allergens
+
+/**
+ * EU 14 mandatory allergens (Regulation 1169/2011 Annex II).
+ * Seeded once via migration; the row count must match
+ * ALLERGEN_CODES in src/features/allergens/schema.ts.
+ *
+ * `code` is the primary key — EU identifiers are stable, no need for prefixed CUIDs.
+ */
+export const allergens = pgTable("allergens", {
+  code: text("code").primaryKey(),
+  nameSk: text("name_sk").notNull(),
+  nameEn: text("name_en").notNull(),
+  sortOrder: integer("sort_order").notNull().default(0),
+});
+
+// #endregion Allergens

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1304,3 +1304,151 @@ export const allergens = pgTable("allergens", {
 });
 
 // #endregion Allergens
+
+// #region Ingredients (Phase B)
+
+export const INGREDIENT_BASE_UNITS = ["g", "piece"] as const;
+export type IngredientBaseUnit = (typeof INGREDIENT_BASE_UNITS)[number];
+
+export const INGREDIENT_NUTRITION_SOURCES = [
+  "manual",
+  "ai",
+  "supplier",
+  "seed",
+] as const;
+export type IngredientNutritionSource =
+  (typeof INGREDIENT_NUTRITION_SOURCES)[number];
+
+/** Nutrition values per 100 g of the ingredient. EU 1169/2011 fields. */
+export interface NutritionPer100 {
+  carbs: number;
+  fat: number;
+  fiber: number;
+  kcal: number;
+  protein: number;
+  salt: number;
+  saturatedFat: number;
+  sugar: number;
+}
+
+/**
+ * Raw-material catalog. Pricing uses XOR: cents/kg for mass, cents/piece
+ * for piece. See docs/specs/_arc-overview.md §3 for the rationale —
+ * per-kg storage is integer-lossless for every realistic supplier price.
+ */
+export const ingredients = pgTable(
+  "ingredients",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createPrefixedId("ing")),
+    name: text("name").notNull().default("Nová surovina"),
+    slug: text("slug")
+      .notNull()
+      .unique()
+      .$defaultFn(() => draftSlug("Nová surovina")),
+
+    baseUnit: text("base_unit")
+      .$type<IngredientBaseUnit>()
+      .notNull()
+      .default("g"),
+    gramsPerPiece: integer("grams_per_piece"),
+
+    pricePerKgCents: integer("price_per_kg_cents"),
+    pricePerPieceCents: integer("price_per_piece_cents"),
+
+    supplierName: text("supplier_name"),
+
+    allergenCodes: text("allergen_codes")
+      .array()
+      .notNull()
+      .default(sql`ARRAY[]::text[]`),
+
+    nutritionPer100: jsonb("nutrition_per_100").$type<NutritionPer100>(),
+    nutritionSource: text("nutrition_source")
+      .$type<IngredientNutritionSource>()
+      .notNull()
+      .default("manual"),
+
+    notes: text("notes"),
+    isActive: boolean("is_active").notNull().default(true),
+
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at")
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (t) => [
+    index("idx_ingredients_slug").on(t.slug),
+    index("idx_ingredients_active").on(t.isActive),
+    check(
+      "ingredients_price_kg_non_negative",
+      sql`${t.pricePerKgCents} IS NULL OR ${t.pricePerKgCents} >= 0`
+    ),
+    check(
+      "ingredients_price_piece_non_negative",
+      sql`${t.pricePerPieceCents} IS NULL OR ${t.pricePerPieceCents} >= 0`
+    ),
+    check(
+      "ingredients_grams_per_piece_when_piece",
+      sql`(${t.baseUnit} <> 'piece') OR (${t.gramsPerPiece} IS NOT NULL AND ${t.gramsPerPiece} > 0)`
+    ),
+    check(
+      "ingredients_price_matches_base_unit",
+      sql`(${t.baseUnit} = 'g'     AND ${t.pricePerKgCents}    IS NOT NULL AND ${t.pricePerPieceCents} IS NULL)
+       OR (${t.baseUnit} = 'piece' AND ${t.pricePerPieceCents} IS NOT NULL AND ${t.pricePerKgCents}    IS NULL)`
+    ),
+  ]
+);
+
+/** Append-only price-change log. Mirrors the ingredients XOR pricing shape. */
+export const ingredientPriceHistory = pgTable(
+  "ingredient_price_history",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => createPrefixedId("iph")),
+    ingredientId: text("ingredient_id")
+      .notNull()
+      .references(() => ingredients.id, { onDelete: "cascade" }),
+    pricePerKgCents: integer("price_per_kg_cents"),
+    pricePerPieceCents: integer("price_per_piece_cents"),
+    supplierName: text("supplier_name"),
+    source: text("source").default("manual").notNull(),
+    notes: text("notes"),
+    effectiveFrom: timestamp("effective_from").defaultNow().notNull(),
+  },
+  (t) => [
+    index("idx_iph_ingredient_effective").on(t.ingredientId, t.effectiveFrom),
+    check(
+      "iph_price_kg_non_negative",
+      sql`${t.pricePerKgCents}    IS NULL OR ${t.pricePerKgCents}    >= 0`
+    ),
+    check(
+      "iph_price_piece_non_negative",
+      sql`${t.pricePerPieceCents} IS NULL OR ${t.pricePerPieceCents} >= 0`
+    ),
+    check(
+      "iph_price_xor",
+      sql`(${t.pricePerKgCents}    IS NOT NULL AND ${t.pricePerPieceCents} IS NULL)
+       OR (${t.pricePerPieceCents} IS NOT NULL AND ${t.pricePerKgCents}    IS NULL)`
+    ),
+  ]
+);
+
+export const ingredientsRelations = relations(ingredients, ({ many }) => ({
+  priceHistory: many(ingredientPriceHistory),
+}));
+
+export const ingredientPriceHistoryRelations = relations(
+  ingredientPriceHistory,
+  ({ one }) => ({
+    ingredient: one(ingredients, {
+      fields: [ingredientPriceHistory.ingredientId],
+      references: [ingredients.id],
+    }),
+  })
+);
+
+// #endregion Ingredients

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -677,10 +677,17 @@ export const orderItems = pgTable(
     productSnapshot: jsonb("product_snapshot").$type<ProductSnapshot>(),
     quantity: integer("quantity").notNull().default(1),
     price: integer("price").notNull(),
+    // Snapshot of computed cost-per-unit at order creation (Phase C populates this).
+    // Nullable: legacy orders + orders for products without a recipe stay null.
+    unitCostCents: integer("unit_cost_cents"),
   },
   (table) => [
     primaryKey({ columns: [table.orderId, table.productId] }),
     check("order_items_price_non_negative", sql`${table.price} >= 0`),
+    check(
+      "order_items_unit_cost_non_negative",
+      sql`${table.unitCostCents} IS NULL OR ${table.unitCostCents} >= 0`
+    ),
   ]
 );
 

--- a/src/features/allergens/api/queries.ts
+++ b/src/features/allergens/api/queries.ts
@@ -1,0 +1,21 @@
+"use cache";
+
+import { asc } from "drizzle-orm";
+import { cacheLife, cacheTag } from "next/cache";
+import { db } from "@/db";
+import { allergens } from "@/db/schema";
+
+/**
+ * The 14 EU allergens, ordered by the canonical sortOrder.
+ *
+ * Cached with cacheLife("max") because the seed never changes after
+ * Phase A migration. If a future localization phase adds rows, invalidate
+ * the "allergens" tag manually.
+ */
+export async function getAllergens() {
+  cacheLife("max");
+  cacheTag("allergens");
+  return await db.select().from(allergens).orderBy(asc(allergens.sortOrder));
+}
+
+export type Allergen = Awaited<ReturnType<typeof getAllergens>>[number];

--- a/src/features/allergens/components/allergen-list.tsx
+++ b/src/features/allergens/components/allergen-list.tsx
@@ -1,0 +1,56 @@
+import { Badge } from "@/components/ui/badge";
+import type { Allergen } from "../api/queries";
+import { ALLERGEN_ICONS } from "../lib/icons";
+import type { AllergenCode } from "../schema";
+
+interface Props {
+  allergens: Allergen[];
+  className?: string;
+  codes: AllergenCode[];
+  heading?: string;
+}
+
+/**
+ * Public PDP allergen list. Renders a labelled chip per allergen present
+ * on the product. Returns null when there are no allergens — silence is
+ * the right UX for products without tagged allergens.
+ *
+ * In Phase A the codes come from products.allergenCodes (manual tagging).
+ * In Phase D, for products with a recipe, codes are derived from the
+ * recipe ingredients. The component is unchanged in either case.
+ */
+export function AllergenList({
+  codes,
+  allergens,
+  className,
+  heading = "Alergény",
+}: Props) {
+  if (codes.length === 0) {
+    return null;
+  }
+
+  // Lookup by code, preserve canonical sortOrder from the reference table
+  const present = allergens.filter((a) =>
+    (codes as readonly string[]).includes(a.code)
+  );
+  if (present.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className={className}>
+      <h3 className="mb-3 font-semibold text-sm tracking-tight">{heading}</h3>
+      <div className="flex flex-wrap gap-2">
+        {present.map((a) => {
+          const Icon = ALLERGEN_ICONS[a.code as AllergenCode];
+          return (
+            <Badge className="gap-1.5" key={a.code} variant="secondary">
+              <Icon className="size-3.5" />
+              {a.nameSk}
+            </Badge>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/features/allergens/components/allergen-picker.tsx
+++ b/src/features/allergens/components/allergen-picker.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import {
+  Controller,
+  type FieldPath,
+  type FieldValues,
+  useFormContext,
+} from "react-hook-form";
+import { Badge } from "@/components/ui/badge";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+} from "@/components/ui/field";
+import { cn } from "@/lib/utils";
+import type { Allergen } from "../api/queries";
+import { ALLERGEN_ICONS } from "../lib/icons";
+import type { AllergenCode } from "../schema";
+
+interface AllergenPickerProps<T extends FieldValues> {
+  allergens: Allergen[];
+  className?: string;
+  description?: string;
+  label?: string;
+  name: FieldPath<T>;
+  /**
+   * When true, picker renders read-only with a note pointing the admin
+   * to the source. Phase D toggles this when a product has a recipe.
+   */
+  readOnly?: boolean;
+  readOnlyNote?: string;
+}
+
+/**
+ * Chip-toggle picker. RHF-controlled; takes the allergens reference list
+ * as a prop so the form's container can fetch it server-side once.
+ *
+ * Sorting is canonical (driven by allergens.sortOrder).
+ */
+export function AllergenPicker<T extends FieldValues>({
+  allergens,
+  className,
+  description,
+  label = "Alergény",
+  name,
+  readOnly = false,
+  readOnlyNote,
+}: AllergenPickerProps<T>) {
+  const { control } = useFormContext();
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => {
+        const value: AllergenCode[] = field.value ?? [];
+        const has = (code: string) =>
+          (value as readonly string[]).includes(code);
+        const toggle = (code: AllergenCode) => {
+          if (readOnly) {
+            return;
+          }
+          field.onChange(
+            has(code) ? value.filter((c) => c !== code) : [...value, code]
+          );
+        };
+
+        return (
+          <Field
+            className={className}
+            data-invalid={fieldState.invalid ? "" : undefined}
+          >
+            <FieldContent>
+              {label && <FieldLabel>{label}</FieldLabel>}
+              {description && (
+                <FieldDescription>{description}</FieldDescription>
+              )}
+              {readOnly && readOnlyNote && (
+                <FieldDescription className="text-muted-foreground italic">
+                  {readOnlyNote}
+                </FieldDescription>
+              )}
+
+              <div className="flex flex-wrap gap-1.5">
+                {allergens.map((a) => {
+                  const Icon = ALLERGEN_ICONS[a.code as AllergenCode];
+                  const selected = has(a.code);
+                  return (
+                    <button
+                      aria-pressed={selected}
+                      className={cn(
+                        "inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1 text-sm transition-colors",
+                        selected
+                          ? "border-primary bg-primary text-primary-foreground hover:bg-primary/90"
+                          : "border-input bg-background hover:bg-accent",
+                        readOnly && "cursor-default opacity-80"
+                      )}
+                      disabled={readOnly}
+                      key={a.code}
+                      onClick={() => toggle(a.code as AllergenCode)}
+                      type="button"
+                    >
+                      <Icon className="size-3.5" />
+                      {a.nameSk}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {value.length > 0 && (
+                <p className="mt-1 text-muted-foreground text-xs">
+                  Vybrané ({value.length}):{" "}
+                  {allergens
+                    .filter((a) => has(a.code))
+                    .map((a) => a.nameSk)
+                    .join(", ")}
+                </p>
+              )}
+            </FieldContent>
+          </Field>
+        );
+      }}
+    />
+  );
+}
+
+/**
+ * Read-only chip strip. Used in product summary cards or anywhere
+ * the admin needs to glance at allergens without editing.
+ */
+export function AllergenChipStrip({
+  allergens,
+  codes,
+  className,
+}: {
+  allergens: Allergen[];
+  codes: AllergenCode[];
+  className?: string;
+}) {
+  const present = allergens.filter((a) =>
+    (codes as readonly string[]).includes(a.code)
+  );
+  if (present.length === 0) {
+    return null;
+  }
+  return (
+    <div className={cn("flex flex-wrap gap-1.5", className)}>
+      {present.map((a) => {
+        const Icon = ALLERGEN_ICONS[a.code as AllergenCode];
+        return (
+          <Badge className="gap-1" key={a.code} variant="secondary">
+            <Icon className="size-3" />
+            {a.nameSk}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/allergens/lib/icons.ts
+++ b/src/features/allergens/lib/icons.ts
@@ -1,0 +1,40 @@
+import {
+  Bean,
+  CircleDot,
+  Egg,
+  Fish,
+  FlaskConical,
+  Flower2,
+  Leaf,
+  type LucideIcon,
+  Milk,
+  Nut,
+  Shell,
+  Sprout,
+  TreePine,
+  Wheat,
+} from "lucide-react";
+import type { AllergenCode } from "../schema";
+
+/**
+ * Lucide icons mapped to each EU 14 allergen code. Not all icons are
+ * perfect food-allergen glyphs (sulphites, sesame, mollusc) but they
+ * cover well enough for a v1 chip strip. Swap to custom SVGs later if
+ * branding wants something more bakery-specific.
+ */
+export const ALLERGEN_ICONS: Record<AllergenCode, LucideIcon> = {
+  gluten: Wheat,
+  crustaceans: Shell,
+  eggs: Egg,
+  fish: Fish,
+  peanuts: Nut,
+  soybeans: Sprout,
+  milk: Milk,
+  tree_nuts: TreePine,
+  celery: Leaf,
+  mustard: Flower2,
+  sesame: CircleDot,
+  sulphites: FlaskConical,
+  lupin: Bean,
+  molluscs: Shell,
+};

--- a/src/features/allergens/schema.ts
+++ b/src/features/allergens/schema.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+/**
+ * EU 14 mandatory allergen codes (Regulation 1169/2011 Annex II).
+ *
+ * This list MUST match the rows seeded into the `allergens` table by
+ * migration 0008. CI check: SELECT count(*) FROM allergens === ALLERGEN_CODES.length.
+ *
+ * Order is informational only; rendering order comes from `allergens.sortOrder`.
+ */
+export const ALLERGEN_CODES = [
+  "gluten",
+  "crustaceans",
+  "eggs",
+  "fish",
+  "peanuts",
+  "soybeans",
+  "milk",
+  "tree_nuts",
+  "celery",
+  "mustard",
+  "sesame",
+  "sulphites",
+  "lupin",
+  "molluscs",
+] as const;
+
+export const allergenCodeSchema = z.enum(ALLERGEN_CODES);
+export type AllergenCode = z.infer<typeof allergenCodeSchema>;
+
+export const updateProductAllergensSchema = z.object({
+  productId: z.string().min(1),
+  codes: z.array(allergenCodeSchema),
+});
+
+export type UpdateProductAllergensSchema = z.infer<
+  typeof updateProductAllergensSchema
+>;

--- a/src/features/ingredients/api/actions.ts
+++ b/src/features/ingredients/api/actions.ts
@@ -1,0 +1,383 @@
+"use server";
+
+import { eq, sql } from "drizzle-orm";
+import { updateTag } from "next/cache";
+import { redirect } from "next/navigation";
+import { db } from "@/db";
+import { ingredientPriceHistory, ingredients } from "@/db/schema";
+import { draftSlug } from "@/db/utils";
+import { requireIngredientEdit } from "@/lib/auth/guards";
+import { log } from "@/lib/logger";
+import {
+  anthropic,
+  extractJsonBlock,
+  NUTRITION_SYSTEM_PROMPT,
+} from "../lib/anthropic";
+import {
+  type AiNutritionSuggestion,
+  aiNutritionSuggestionSchema,
+  type IngredientSchema,
+  ingredientSchema,
+} from "../schema";
+import { findSimilarIngredients } from "./queries";
+
+type ActionResult<T = void> =
+  | (T extends void ? { success: true } : { success: true } & T)
+  | { success: false; error: string };
+
+function invalidateIngredients(id?: string, priceChanged = false) {
+  updateTag("ingredients");
+  if (id) {
+    updateTag(`ingredient-${id}`);
+  }
+  if (priceChanged) {
+    if (id) {
+      updateTag(`ingredient-${id}-prices`);
+    }
+    // Recipes' computed cost depends on ingredient prices; reports too.
+    updateTag("recipes");
+    updateTag("reports");
+  }
+}
+
+/**
+ * Create a new ingredient + initial price-history row. Returns the
+ * created ingredient so the recipe builder's inline-create flow can
+ * autofill the picker without a redirect.
+ */
+export async function createIngredientAction(
+  data: IngredientSchema
+): Promise<ActionResult<{ ingredient: { id: string; name: string } }>> {
+  await requireIngredientEdit();
+  const parsed = ingredientSchema.safeParse(data);
+  if (!parsed.success) {
+    return { success: false, error: "Neplatné údaje" };
+  }
+  const v = parsed.data;
+
+  try {
+    const [created] = await db
+      .insert(ingredients)
+      .values({
+        name: v.name,
+        slug: v.slug || draftSlug(v.name),
+        baseUnit: v.baseUnit,
+        gramsPerPiece: v.gramsPerPiece,
+        pricePerKgCents: v.pricePerKgCents,
+        pricePerPieceCents: v.pricePerPieceCents,
+        supplierName: v.supplierName,
+        allergenCodes: v.allergenCodes,
+        nutritionPer100: v.nutritionPer100,
+        nutritionSource: v.nutritionSource,
+        notes: v.notes,
+        isActive: v.isActive,
+      })
+      .returning({ id: ingredients.id, name: ingredients.name });
+
+    // History row mirrors the new price. Append AFTER ingredient is created
+    // so the FK is satisfied; insert failure here only means we lost the
+    // initial history row, the ingredient itself remains usable.
+    try {
+      await db.insert(ingredientPriceHistory).values({
+        ingredientId: created.id,
+        pricePerKgCents: v.pricePerKgCents,
+        pricePerPieceCents: v.pricePerPieceCents,
+        supplierName: v.supplierName,
+        source: v.nutritionSource === "seed" ? "seed" : "manual",
+        notes: "Initial price",
+      });
+    } catch (err) {
+      log.ingredients.warn(
+        { err, ingredientId: created.id },
+        "Initial price-history insert failed; ingredient created"
+      );
+    }
+
+    invalidateIngredients(undefined, true);
+    return { success: true, ingredient: created };
+  } catch (err) {
+    log.ingredients.error({ err }, "Create ingredient failed");
+    return { success: false, error: "Vytvorenie zlyhalo" };
+  }
+}
+
+/**
+ * Update an ingredient. When the price changes, append a history row
+ * BEFORE updating so a partial-failure scenario leaves the audit log
+ * complete and the user retries (rather than silently losing a price
+ * change).
+ */
+export async function updateIngredientAction({
+  id,
+  data,
+}: {
+  id: string;
+  data: IngredientSchema;
+}): Promise<ActionResult> {
+  await requireIngredientEdit();
+  const parsed = ingredientSchema.safeParse(data);
+  if (!parsed.success) {
+    return { success: false, error: "Neplatné údaje" };
+  }
+  const v = parsed.data;
+
+  const current = await db
+    .select({
+      pricePerKgCents: ingredients.pricePerKgCents,
+      pricePerPieceCents: ingredients.pricePerPieceCents,
+      supplierName: ingredients.supplierName,
+    })
+    .from(ingredients)
+    .where(eq(ingredients.id, id))
+    .limit(1);
+  if (!current[0]) {
+    return { success: false, error: "Surovina neexistuje" };
+  }
+
+  const priceChanged =
+    current[0].pricePerKgCents !== v.pricePerKgCents ||
+    current[0].pricePerPieceCents !== v.pricePerPieceCents ||
+    current[0].supplierName !== v.supplierName;
+
+  try {
+    if (priceChanged) {
+      await db.insert(ingredientPriceHistory).values({
+        ingredientId: id,
+        pricePerKgCents: v.pricePerKgCents,
+        pricePerPieceCents: v.pricePerPieceCents,
+        supplierName: v.supplierName,
+        source: v.nutritionSource === "ai" ? "ai" : "manual",
+      });
+    }
+
+    await db
+      .update(ingredients)
+      .set({
+        name: v.name,
+        slug: v.slug,
+        baseUnit: v.baseUnit,
+        gramsPerPiece: v.gramsPerPiece,
+        pricePerKgCents: v.pricePerKgCents,
+        pricePerPieceCents: v.pricePerPieceCents,
+        supplierName: v.supplierName,
+        allergenCodes: v.allergenCodes,
+        nutritionPer100: v.nutritionPer100,
+        nutritionSource: v.nutritionSource,
+        notes: v.notes,
+        isActive: v.isActive,
+      })
+      .where(eq(ingredients.id, id));
+
+    invalidateIngredients(id, priceChanged);
+    return { success: true };
+  } catch (err) {
+    log.ingredients.error(
+      { err, ingredientId: id },
+      "Update ingredient failed"
+    );
+    return { success: false, error: "Uloženie zlyhalo" };
+  }
+}
+
+/**
+ * Toggle the isActive flag. Soft-deactivation keeps the row but hides
+ * it from new recipe picker selections.
+ */
+export async function setIngredientActiveAction({
+  id,
+  isActive,
+}: {
+  id: string;
+  isActive: boolean;
+}): Promise<ActionResult> {
+  await requireIngredientEdit();
+  try {
+    await db
+      .update(ingredients)
+      .set({ isActive })
+      .where(eq(ingredients.id, id));
+    invalidateIngredients(id);
+    return { success: true };
+  } catch (err) {
+    log.ingredients.error({ err, ingredientId: id }, "Toggle active failed");
+    return { success: false, error: "Operácia zlyhala" };
+  }
+}
+
+/**
+ * Hard delete an ingredient. Blocked when any recipe items reference it
+ * (Phase C check via raw SQL; no-op until Phase C ships recipe_items).
+ */
+export async function deleteIngredientAction({
+  id,
+}: {
+  id: string;
+}): Promise<ActionResult> {
+  await requireIngredientEdit();
+  try {
+    // Defensive check: query recipe_items by ingredient_id if the table exists.
+    // We do it via information_schema so this code keeps working both before
+    // and after Phase C lands.
+    const inUse = await db.execute(sql`
+      WITH has_table AS (
+        SELECT EXISTS (
+          SELECT 1 FROM information_schema.tables
+          WHERE table_schema = 'public' AND table_name = 'recipe_items'
+        ) AS exists
+      )
+      SELECT CASE
+        WHEN (SELECT exists FROM has_table) IS NOT TRUE THEN false
+        ELSE EXISTS (
+          SELECT 1 FROM recipe_items WHERE ingredient_id = ${id}
+        )
+      END AS in_use
+    `);
+    const inUseRow = inUse.rows[0] as { in_use: boolean } | undefined;
+    if (inUseRow?.in_use) {
+      return {
+        success: false,
+        error: "Surovina je použitá v receptoch a nemôže byť odstránená.",
+      };
+    }
+
+    await db.delete(ingredients).where(eq(ingredients.id, id));
+    invalidateIngredients(id);
+    return { success: true };
+  } catch (err) {
+    log.ingredients.error(
+      { err, ingredientId: id },
+      "Delete ingredient failed"
+    );
+    return { success: false, error: "Odstránenie zlyhalo" };
+  }
+}
+
+/**
+ * Read-only AI nutrition suggestion. The admin reviews the suggestion
+ * in a dialog and then persists via updateIngredientAction with
+ * nutritionSource: 'ai'. This action never writes to the DB.
+ */
+export async function aiAutofillNutritionAction({
+  ingredientId,
+}: {
+  ingredientId: string;
+}): Promise<ActionResult<{ suggestion: AiNutritionSuggestion }>> {
+  await requireIngredientEdit();
+
+  if (!anthropic) {
+    return {
+      success: false,
+      error: "AI funkcia nie je nakonfigurované (chýba ANTHROPIC_API_KEY)",
+    };
+  }
+
+  const row = await db
+    .select({
+      name: ingredients.name,
+      supplierName: ingredients.supplierName,
+      baseUnit: ingredients.baseUnit,
+      gramsPerPiece: ingredients.gramsPerPiece,
+    })
+    .from(ingredients)
+    .where(eq(ingredients.id, ingredientId))
+    .limit(1);
+  if (!row[0]) {
+    return { success: false, error: "Surovina neexistuje" };
+  }
+
+  const i = row[0];
+  const userContent = `Surovina: ${i.name}${i.supplierName ? ` (${i.supplierName})` : ""}
+Jednotka: ${i.baseUnit === "g" ? "100 g" : `1 kus = ${i.gramsPerPiece ?? "?"} g, hodnoty na 100 g`}`;
+
+  try {
+    const message = await anthropic.messages.create({
+      model: "claude-sonnet-4-5",
+      max_tokens: 512,
+      system: [
+        {
+          type: "text",
+          text: NUTRITION_SYSTEM_PROMPT,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [{ role: "user", content: userContent }],
+    });
+
+    const text =
+      message.content[0]?.type === "text" ? message.content[0].text : "";
+    if (!text) {
+      return { success: false, error: "AI nevrátila odpoveď" };
+    }
+
+    let json: unknown;
+    try {
+      json = JSON.parse(extractJsonBlock(text));
+    } catch (err) {
+      log.ingredients.error(
+        { err, ingredientId, raw: text },
+        "AI returned non-JSON"
+      );
+      return { success: false, error: "AI vrátila nesprávny formát" };
+    }
+
+    const parsed = aiNutritionSuggestionSchema.safeParse(json);
+    if (!parsed.success) {
+      log.ingredients.error(
+        { ingredientId, raw: text, issues: parsed.error.issues },
+        "AI response failed schema validation"
+      );
+      return { success: false, error: "AI vrátila neplatné hodnoty" };
+    }
+
+    return { success: true, suggestion: parsed.data };
+  } catch (err) {
+    log.ingredients.error({ err, ingredientId }, "AI autofill call failed");
+    return { success: false, error: "AI volanie zlyhalo" };
+  }
+}
+
+/**
+ * Create a draft ingredient with the minimal CHECK-satisfying defaults
+ * and redirect to its edit page. Used by the "Nová surovina" button.
+ */
+export async function createDraftIngredientAction() {
+  await requireIngredientEdit();
+
+  const [created] = await db
+    .insert(ingredients)
+    .values({
+      // baseUnit defaults to 'g' via schema; pair it with cents/kg = 0 so
+      // the XOR CHECK is satisfied. Admin enters a real price next.
+      pricePerKgCents: 0,
+    })
+    .returning({ id: ingredients.id });
+
+  try {
+    await db.insert(ingredientPriceHistory).values({
+      ingredientId: created.id,
+      pricePerKgCents: 0,
+      source: "manual",
+      notes: "Initial draft",
+    });
+  } catch (err) {
+    log.ingredients.warn(
+      { err, ingredientId: created.id },
+      "Draft price-history insert failed"
+    );
+  }
+
+  updateTag("ingredients");
+  redirect(`/admin/ingredients/${created.id}`);
+}
+
+/**
+ * Server-action wrapper around findSimilarIngredients for client-side
+ * use from the duplicate-suggestion component.
+ */
+export async function findSimilarIngredientsAction(name: string) {
+  await requireIngredientEdit();
+  if (!name || name.trim().length < 2) {
+    return [];
+  }
+  return findSimilarIngredients(name);
+}

--- a/src/features/ingredients/api/queries.ts
+++ b/src/features/ingredients/api/queries.ts
@@ -1,0 +1,164 @@
+"use cache";
+
+import { and, asc, desc, eq, isNull, or, sql } from "drizzle-orm";
+import { cacheLife, cacheTag } from "next/cache";
+import { db } from "@/db";
+import { ingredientPriceHistory, ingredients } from "@/db/schema";
+
+interface ListOpts {
+  isActive?: boolean;
+  missingNutrition?: boolean;
+  missingPrice?: boolean;
+  search?: string;
+}
+
+/**
+ * Admin ingredient list. Search uses trigram similarity over
+ * lower(f_unaccent(name)), so "muka" matches "Hladká múka T650".
+ */
+export async function getIngredients(opts: ListOpts = {}) {
+  cacheLife("hours");
+  cacheTag("ingredients");
+
+  const filters = [] as ReturnType<typeof eq>[];
+  if (typeof opts.isActive === "boolean") {
+    filters.push(eq(ingredients.isActive, opts.isActive));
+  }
+  if (opts.missingPrice) {
+    const missing = or(
+      eq(ingredients.pricePerKgCents, 0),
+      eq(ingredients.pricePerPieceCents, 0)
+    );
+    if (missing) {
+      filters.push(missing);
+    }
+  }
+  if (opts.missingNutrition) {
+    filters.push(isNull(ingredients.nutritionPer100));
+  }
+
+  if (opts.search && opts.search.length > 0) {
+    const term = opts.search;
+    // pg_trgm threshold 0.3 keeps results loose enough for typos
+    filters.push(
+      sql`similarity(lower(f_unaccent(${ingredients.name})), lower(f_unaccent(${term}))) > 0.3
+       OR lower(f_unaccent(${ingredients.name})) ILIKE '%' || lower(f_unaccent(${term})) || '%'`
+    );
+  }
+
+  return await db
+    .select()
+    .from(ingredients)
+    .where(filters.length > 0 ? and(...filters) : undefined)
+    .orderBy(asc(ingredients.name))
+    .limit(500);
+}
+
+export type IngredientListRow = Awaited<
+  ReturnType<typeof getIngredients>
+>[number];
+
+export async function getIngredientById(id: string) {
+  cacheLife("hours");
+  cacheTag("ingredients", `ingredient-${id}`);
+
+  const row = await db
+    .select()
+    .from(ingredients)
+    .where(eq(ingredients.id, id))
+    .limit(1);
+  return row[0] ?? null;
+}
+
+export type Ingredient = NonNullable<
+  Awaited<ReturnType<typeof getIngredientById>>
+>;
+
+export async function getIngredientPriceHistory(id: string, limit = 50) {
+  cacheLife("hours");
+  cacheTag(`ingredient-${id}-prices`);
+
+  return await db
+    .select()
+    .from(ingredientPriceHistory)
+    .where(eq(ingredientPriceHistory.ingredientId, id))
+    .orderBy(desc(ingredientPriceHistory.effectiveFrom))
+    .limit(limit);
+}
+
+/**
+ * Lightweight catalog used by Phase C's resolver context. Returns only
+ * the columns the resolver needs, filtered to active ingredients.
+ */
+export async function getIngredientsForResolver() {
+  cacheLife("hours");
+  cacheTag("ingredients");
+
+  return await db
+    .select({
+      id: ingredients.id,
+      name: ingredients.name,
+      baseUnit: ingredients.baseUnit,
+      gramsPerPiece: ingredients.gramsPerPiece,
+      pricePerKgCents: ingredients.pricePerKgCents,
+      pricePerPieceCents: ingredients.pricePerPieceCents,
+      allergenCodes: ingredients.allergenCodes,
+      nutritionPer100: ingredients.nutritionPer100,
+    })
+    .from(ingredients)
+    .where(eq(ingredients.isActive, true));
+}
+
+export type IngredientForResolver = Awaited<
+  ReturnType<typeof getIngredientsForResolver>
+>[number];
+
+/**
+ * Trigram similarity lookup used by the duplicate-suggestion UI when
+ * the admin types a new ingredient name.
+ */
+export async function findSimilarIngredients(name: string, limit = 5) {
+  cacheLife("hours");
+  cacheTag("ingredients");
+
+  if (!name || name.trim().length === 0) {
+    return [];
+  }
+
+  const rows = await db.execute(sql`
+    SELECT id, name,
+      similarity(lower(f_unaccent(name)), lower(f_unaccent(${name}))) AS score
+    FROM ingredients
+    WHERE similarity(lower(f_unaccent(name)), lower(f_unaccent(${name}))) > 0.6
+    ORDER BY score DESC
+    LIMIT ${limit}
+  `);
+  return rows.rows as Array<{ id: string; name: string; score: number }>;
+}
+
+/**
+ * Pairs of near-duplicate ingredients above a threshold. Used by the
+ * /admin/ingredients/duplicates review page. Read-only diagnostic.
+ */
+export async function getIngredientDuplicates(threshold = 0.7) {
+  cacheLife("hours");
+  cacheTag("ingredients");
+
+  const rows = await db.execute(sql`
+    SELECT a.id AS a_id, a.name AS a_name, b.id AS b_id, b.name AS b_name,
+      similarity(lower(f_unaccent(a.name)), lower(f_unaccent(b.name))) AS score
+    FROM ingredients a
+    JOIN ingredients b
+      ON a.id < b.id
+     AND similarity(lower(f_unaccent(a.name)), lower(f_unaccent(b.name))) > ${threshold}
+    ORDER BY score DESC
+    LIMIT 100
+  `);
+  return rows.rows as Array<{
+    a_id: string;
+    a_name: string;
+    b_id: string;
+    b_name: string;
+    score: number;
+  }>;
+}

--- a/src/features/ingredients/components/ai-suggestion-dialog.tsx
+++ b/src/features/ingredients/components/ai-suggestion-dialog.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { SparklesIcon } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { aiAutofillNutritionAction } from "../api/actions";
+import type { AiNutritionSuggestion, NutritionPer100Schema } from "../schema";
+
+const FIELD_LABELS: Array<{
+  key: keyof NutritionPer100Schema;
+  label: string;
+  unit: string;
+}> = [
+  { key: "kcal", label: "Energia", unit: "kcal" },
+  { key: "protein", label: "Bielkoviny", unit: "g" },
+  { key: "fat", label: "Tuky", unit: "g" },
+  { key: "saturatedFat", label: "nasýtené", unit: "g" },
+  { key: "carbs", label: "Sacharidy", unit: "g" },
+  { key: "sugar", label: "cukry", unit: "g" },
+  { key: "fiber", label: "Vláknina", unit: "g" },
+  { key: "salt", label: "Soľ", unit: "g" },
+];
+
+interface Props {
+  current: Partial<NutritionPer100Schema> | null;
+  disabled?: boolean;
+  disabledReason?: string;
+  ingredientId: string;
+  /** Called when admin confirms; parent applies via updateIngredientAction. */
+  onApply: (suggestion: AiNutritionSuggestion) => void;
+}
+
+/**
+ * `[Vyplniť pomocou AI]` button + confirmation dialog.
+ *
+ * Flow:
+ * 1. Click button → call aiAutofillNutritionAction (read-only)
+ * 2. Show suggested values side-by-side with current
+ * 3. Admin confirms → onApply → parent persists via updateIngredientAction
+ */
+export function AiSuggestionDialog({
+  ingredientId,
+  current,
+  onApply,
+  disabled,
+  disabledReason,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [suggestion, setSuggestion] = useState<AiNutritionSuggestion | null>(
+    null
+  );
+
+  const handleOpenChange = async (next: boolean) => {
+    setOpen(next);
+    if (!next) {
+      setSuggestion(null);
+      return;
+    }
+    // Trigger the AI call when the dialog opens.
+    setLoading(true);
+    setSuggestion(null);
+    try {
+      const result = await aiAutofillNutritionAction({ ingredientId });
+      if (result.success) {
+        setSuggestion(result.suggestion);
+      } else {
+        toast.error(result.error);
+        setOpen(false);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AlertDialog onOpenChange={handleOpenChange} open={open}>
+      <AlertDialogTrigger asChild>
+        <Button
+          disabled={disabled}
+          size="sm"
+          title={disabledReason}
+          type="button"
+          variant="outline"
+        >
+          <SparklesIcon className="mr-1.5 size-4" />
+          Vyplniť pomocou AI
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Návrh nutričných hodnôt</AlertDialogTitle>
+          <AlertDialogDescription>
+            AI navrhuje nasledujúce hodnoty na 100 g. Skontrolujte ich a
+            potvrďte; potvrdením sa nahradia existujúce hodnoty.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {loading && (
+          <div className="flex items-center justify-center gap-2 py-8 text-muted-foreground">
+            <Spinner /> Pýtam sa AI...
+          </div>
+        )}
+
+        {suggestion && (
+          <div className="grid gap-3 text-sm">
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground">Spoľahlivosť:</span>
+              <Badge variant={confidenceVariant(suggestion.confidence)}>
+                {confidenceLabel(suggestion.confidence)}
+              </Badge>
+            </div>
+            <p className="text-muted-foreground text-xs">
+              Zdroj: {suggestion.source}
+            </p>
+            <table className="w-full text-sm">
+              <thead className="text-muted-foreground text-xs">
+                <tr>
+                  <th className="text-left">Hodnota</th>
+                  <th className="text-right">Aktuálne</th>
+                  <th className="text-right">Návrh</th>
+                </tr>
+              </thead>
+              <tbody>
+                {FIELD_LABELS.map((f) => {
+                  const cur = current?.[f.key];
+                  const next = suggestion[f.key];
+                  const changed = cur !== next;
+                  return (
+                    <tr className="border-t" key={f.key}>
+                      <td className="py-1.5">{f.label}</td>
+                      <td className="text-right text-muted-foreground">
+                        {cur === undefined || cur === null
+                          ? "—"
+                          : `${cur} ${f.unit}`}
+                      </td>
+                      <td
+                        className={
+                          changed
+                            ? "text-right font-medium"
+                            : "text-right text-muted-foreground"
+                        }
+                      >
+                        {next} {f.unit}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>Zrušiť</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={!suggestion}
+            onClick={() => {
+              if (suggestion) {
+                onApply(suggestion);
+                setOpen(false);
+              }
+            }}
+          >
+            Použiť hodnoty
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function confidenceVariant(
+  c: AiNutritionSuggestion["confidence"]
+): "success" | "secondary" | "destructive" {
+  if (c === "high") {
+    return "success";
+  }
+  if (c === "medium") {
+    return "secondary";
+  }
+  return "destructive";
+}
+
+function confidenceLabel(c: AiNutritionSuggestion["confidence"]): string {
+  if (c === "high") {
+    return "Vysoká";
+  }
+  if (c === "medium") {
+    return "Stredná";
+  }
+  return "Nízka";
+}

--- a/src/features/ingredients/components/duplicate-suggestion.tsx
+++ b/src/features/ingredients/components/duplicate-suggestion.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+interface SimilarIngredient {
+  id: string;
+  name: string;
+  score: number;
+}
+
+interface Props {
+  /** server action wrapper that queries findSimilarIngredients */
+  fetcher: (name: string) => Promise<SimilarIngredient[]>;
+  name: string;
+}
+
+/**
+ * Tiny inline suggester rendered under the ingredient name field on the
+ * create form. Debounces, queries the trigram similarity, and renders
+ * clickable chips when matches > 0.6.
+ */
+export function DuplicateSuggestion({ name, fetcher }: Props) {
+  const [matches, setMatches] = useState<SimilarIngredient[]>([]);
+
+  useEffect(() => {
+    if (!name || name.trim().length < 2) {
+      setMatches([]);
+      return;
+    }
+    const handle = setTimeout(async () => {
+      try {
+        const found = await fetcher(name);
+        setMatches(found);
+      } catch {
+        setMatches([]);
+      }
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [name, fetcher]);
+
+  if (matches.length === 0) {
+    return null;
+  }
+
+  return (
+    <p className="mt-1 text-amber-600 text-xs dark:text-amber-400">
+      Možno máte na mysli:{" "}
+      {matches.map((m, idx) => (
+        <span key={m.id}>
+          <Link
+            className="underline hover:text-amber-700"
+            href={`/admin/ingredients/${m.id}` as never}
+          >
+            {m.name}
+          </Link>
+          {idx < matches.length - 1 ? ", " : ""}
+        </span>
+      ))}
+    </p>
+  );
+}

--- a/src/features/ingredients/components/ingredient-form.tsx
+++ b/src/features/ingredients/components/ingredient-form.tsx
@@ -1,0 +1,511 @@
+"use client";
+
+import { Trash2Icon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldSet,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import type { Allergen } from "@/features/allergens/api/queries";
+import { AllergenChipStrip } from "@/features/allergens/components/allergen-picker";
+import { ALLERGEN_ICONS } from "@/features/allergens/lib/icons";
+import type { AllergenCode } from "@/features/allergens/schema";
+import { cn } from "@/lib/utils";
+import {
+  createIngredientAction,
+  deleteIngredientAction,
+  findSimilarIngredientsAction,
+  setIngredientActiveAction,
+  updateIngredientAction,
+} from "../api/actions";
+import type { Ingredient } from "../api/queries";
+import { suggestAllergens } from "../lib/allergen-defaults";
+import type { IngredientSchema } from "../schema";
+import { AiSuggestionDialog } from "./ai-suggestion-dialog";
+import { DuplicateSuggestion } from "./duplicate-suggestion";
+import { NutritionFields } from "./nutrition-fields";
+import { PriceInput } from "./price-input";
+
+type FormState = IngredientSchema;
+
+interface Props {
+  allergens: Allergen[];
+  initial?: Ingredient;
+  onSaved?: (ingredient: { id: string; name: string }) => void;
+  variant?: "page" | "sheet";
+}
+
+/**
+ * Ingredient form, dual-mode: "page" (full standalone editor) and
+ * "sheet" (compact, used by Phase C's recipe builder inline-create flow).
+ */
+export function IngredientForm({
+  initial,
+  allergens,
+  variant = "page",
+  onSaved,
+}: Props) {
+  const router = useRouter();
+  const isCreate = !initial;
+
+  const [state, setState] = useState<FormState>(() =>
+    seedState(initial, allergens)
+  );
+  const [submitting, startTransition] = useTransition();
+  const [deleting, setDeleting] = useState(false);
+
+  const suggested = suggestAllergens(state.name).filter(
+    (c) => !(state.allergenCodes as readonly string[]).includes(c)
+  );
+
+  const update = <K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setState((s) => ({ ...s, [key]: value }));
+  };
+
+  const toggleAllergen = (code: AllergenCode) => {
+    const has = (state.allergenCodes as readonly string[]).includes(code);
+    update(
+      "allergenCodes",
+      has
+        ? state.allergenCodes.filter((c) => c !== code)
+        : [...state.allergenCodes, code]
+    );
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    startTransition(async () => {
+      if (isCreate) {
+        const res = await createIngredientAction(state);
+        if (res.success) {
+          toast.success("Surovina vytvorená");
+          onSaved?.(res.ingredient);
+          if (variant === "page") {
+            router.push(`/admin/ingredients/${res.ingredient.id}` as never);
+          }
+        } else {
+          toast.error(res.error);
+        }
+      } else {
+        const res = await updateIngredientAction({
+          id: initial.id,
+          data: state,
+        });
+        if (res.success) {
+          toast.success("Surovina uložená");
+          router.refresh();
+        } else {
+          toast.error(res.error);
+        }
+      }
+    });
+  };
+
+  const handleDelete = async () => {
+    if (!initial) {
+      return;
+    }
+    setDeleting(true);
+    try {
+      const res = await deleteIngredientAction({ id: initial.id });
+      if (res.success) {
+        toast.success("Surovina odstránená");
+        router.push("/admin/ingredients");
+      } else {
+        toast.error(res.error);
+      }
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleToggleActive = async () => {
+    if (!initial) {
+      update("isActive", !state.isActive);
+      return;
+    }
+    const next = !state.isActive;
+    update("isActive", next);
+    const res = await setIngredientActiveAction({
+      id: initial.id,
+      isActive: next,
+    });
+    if (!res.success) {
+      toast.error(res.error);
+      update("isActive", !next);
+    }
+  };
+
+  return (
+    <form
+      className={cn("grid gap-6", variant === "page" ? "max-w-3xl p-4" : "p-4")}
+      onSubmit={handleSubmit}
+    >
+      {/* Basic info */}
+      <FieldSet>
+        <FieldLabel>Základné údaje</FieldLabel>
+        <FieldGroup className="grid gap-4 md:grid-cols-2">
+          <Field>
+            <FieldContent>
+              <FieldLabel htmlFor="ing-name">Názov</FieldLabel>
+            </FieldContent>
+            <Input
+              id="ing-name"
+              onChange={(e) => update("name", e.target.value)}
+              placeholder="Hladká múka T650"
+              value={state.name}
+            />
+            {isCreate && (
+              <DuplicateSuggestion
+                fetcher={findSimilarIngredientsAction}
+                name={state.name}
+              />
+            )}
+          </Field>
+
+          <Field>
+            <FieldContent>
+              <FieldLabel htmlFor="ing-slug">Slug</FieldLabel>
+            </FieldContent>
+            <Input
+              id="ing-slug"
+              onChange={(e) => update("slug", e.target.value)}
+              value={state.slug}
+            />
+          </Field>
+
+          <Field>
+            <FieldContent>
+              <FieldLabel htmlFor="ing-supplier">Dodávateľ</FieldLabel>
+              <FieldDescription>Nepovinné</FieldDescription>
+            </FieldContent>
+            <Input
+              id="ing-supplier"
+              onChange={(e) => update("supplierName", e.target.value || null)}
+              value={state.supplierName ?? ""}
+            />
+          </Field>
+
+          <Field className="md:col-span-2">
+            <FieldContent>
+              <FieldLabel htmlFor="ing-notes">Poznámky</FieldLabel>
+            </FieldContent>
+            <Textarea
+              id="ing-notes"
+              onChange={(e) => update("notes", e.target.value || null)}
+              rows={2}
+              value={state.notes ?? ""}
+            />
+          </Field>
+        </FieldGroup>
+      </FieldSet>
+
+      {/* Unit + price */}
+      <FieldSet>
+        <FieldLabel>Jednotka a cena</FieldLabel>
+        <FieldGroup className="grid gap-4 md:grid-cols-2">
+          <Field>
+            <FieldContent>
+              <FieldLabel>Základná jednotka</FieldLabel>
+              <FieldDescription>
+                Hmotnostné suroviny: g. Kusové: piece (vajcia, citróny).
+              </FieldDescription>
+            </FieldContent>
+            <Select
+              onValueChange={(v) => {
+                const baseUnit = v as "g" | "piece";
+                // When switching units, clear the off-axis price so the
+                // XOR CHECK is satisfied.
+                update("baseUnit", baseUnit);
+                if (baseUnit === "g") {
+                  update("pricePerPieceCents", null);
+                  if (state.pricePerKgCents === null) {
+                    update("pricePerKgCents", 0);
+                  }
+                } else {
+                  update("pricePerKgCents", null);
+                  if (state.pricePerPieceCents === null) {
+                    update("pricePerPieceCents", 0);
+                  }
+                }
+              }}
+              value={state.baseUnit}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="g">Hmotnosť (g)</SelectItem>
+                <SelectItem value="piece">Kus (piece)</SelectItem>
+              </SelectContent>
+            </Select>
+          </Field>
+
+          {state.baseUnit === "piece" && (
+            <Field>
+              <FieldContent>
+                <FieldLabel htmlFor="ing-gpp">Hmotnosť na kus (g)</FieldLabel>
+                <FieldDescription>
+                  Použité pre prepočet nutrície (napr. vajce M = 50 g).
+                </FieldDescription>
+              </FieldContent>
+              <Input
+                id="ing-gpp"
+                inputMode="numeric"
+                onChange={(e) =>
+                  update(
+                    "gramsPerPiece",
+                    e.target.value === "" ? null : Number(e.target.value)
+                  )
+                }
+                placeholder="50"
+                type="number"
+                value={state.gramsPerPiece ?? ""}
+              />
+            </Field>
+          )}
+
+          <Field className="md:col-span-2">
+            <PriceInput
+              baseUnit={state.baseUnit}
+              description="Zadajte sumu v jednotke, ktorú máte na faktúre. Uložené ako cents/kg alebo cents/ks."
+              onChange={({ pricePerKgCents, pricePerPieceCents }) => {
+                setState((s) => ({
+                  ...s,
+                  pricePerKgCents,
+                  pricePerPieceCents,
+                }));
+              }}
+              pricePerKgCents={state.pricePerKgCents}
+              pricePerPieceCents={state.pricePerPieceCents}
+            />
+          </Field>
+        </FieldGroup>
+      </FieldSet>
+
+      {/* Allergens */}
+      <FieldSet>
+        <FieldLabel>Alergény</FieldLabel>
+        <FieldDescription>
+          Označte alergény, ktoré surovina obsahuje. Po pridaní surovín do
+          receptu sa alergény odovzdajú produktu automaticky.
+        </FieldDescription>
+
+        {suggested.length > 0 && (
+          <div className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs dark:border-amber-800 dark:bg-amber-950">
+            <p className="mb-1 text-amber-700 dark:text-amber-300">
+              Navrhnuté podľa názvu:
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {suggested.map((code) => {
+                const a = allergens.find((x) => x.code === code);
+                if (!a) {
+                  return null;
+                }
+                const Icon = ALLERGEN_ICONS[code];
+                return (
+                  <button
+                    className="inline-flex cursor-pointer items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-xs hover:bg-accent"
+                    key={code}
+                    onClick={() => toggleAllergen(code)}
+                    type="button"
+                  >
+                    <Icon className="size-3" />
+                    {a.nameSk} +
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-1.5">
+          {allergens.map((a) => {
+            const Icon = ALLERGEN_ICONS[a.code as AllergenCode];
+            const selected = (
+              state.allergenCodes as readonly string[]
+            ).includes(a.code);
+            return (
+              <button
+                aria-pressed={selected}
+                className={cn(
+                  "inline-flex cursor-pointer items-center gap-1.5 rounded-full border px-3 py-1 text-sm transition-colors",
+                  selected
+                    ? "border-primary bg-primary text-primary-foreground hover:bg-primary/90"
+                    : "border-input bg-background hover:bg-accent"
+                )}
+                key={a.code}
+                onClick={() => toggleAllergen(a.code as AllergenCode)}
+                type="button"
+              >
+                <Icon className="size-3.5" />
+                {a.nameSk}
+              </button>
+            );
+          })}
+        </div>
+
+        {state.allergenCodes.length > 0 && (
+          <AllergenChipStrip
+            allergens={allergens}
+            codes={state.allergenCodes}
+          />
+        )}
+      </FieldSet>
+
+      {/* Nutrition */}
+      <FieldSet>
+        <div className="flex items-center justify-between gap-2">
+          <div>
+            <FieldLabel>Nutričné hodnoty (na 100 g)</FieldLabel>
+            <FieldDescription>
+              Energia, makroživiny a soľ. Použité pre výpočet nutrície hotových
+              produktov (Phase D).
+            </FieldDescription>
+          </div>
+          <div className="flex items-center gap-2">
+            <Badge variant="secondary">
+              Zdroj: {sourceLabel(state.nutritionSource)}
+            </Badge>
+            {!isCreate && initial && (
+              <AiSuggestionDialog
+                current={state.nutritionPer100}
+                ingredientId={initial.id}
+                onApply={(s) => {
+                  const { confidence, source, ...nutrition } = s;
+                  setState((prev) => ({
+                    ...prev,
+                    nutritionPer100: nutrition,
+                    nutritionSource: "ai",
+                  }));
+                  toast.info(
+                    `Návrh AI použitý (spoľahlivosť: ${confidence}, zdroj: ${source})`
+                  );
+                }}
+              />
+            )}
+          </div>
+        </div>
+        <NutritionFields
+          onChange={(next) => {
+            setState((prev) => ({
+              ...prev,
+              nutritionPer100: next as IngredientSchema["nutritionPer100"],
+              // If admin edits values manually, mark source as manual
+              nutritionSource:
+                prev.nutritionSource === "ai" ? prev.nutritionSource : "manual",
+            }));
+          }}
+          value={state.nutritionPer100}
+        />
+      </FieldSet>
+
+      {/* Visibility + actions */}
+      {variant === "page" && (
+        <FieldSet>
+          <FieldLabel>Stav</FieldLabel>
+          <Field orientation="horizontal">
+            <Switch
+              checked={state.isActive}
+              id="ing-active"
+              onCheckedChange={handleToggleActive}
+            />
+            <FieldContent>
+              <FieldLabel htmlFor="ing-active">Aktívna</FieldLabel>
+              <FieldDescription>
+                Neaktívne suroviny sa nezobrazujú v pickeri receptov.
+              </FieldDescription>
+            </FieldContent>
+          </Field>
+        </FieldSet>
+      )}
+
+      <div className="flex items-center justify-end gap-2">
+        {variant === "page" && initial && (
+          <Button
+            disabled={deleting || submitting}
+            onClick={handleDelete}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            <Trash2Icon className="mr-1.5 size-4" />
+            Odstrániť
+          </Button>
+        )}
+        <Button disabled={submitting} size="sm" type="submit">
+          {submitting && <Spinner />}
+          {isCreate ? "Vytvoriť" : "Uložiť"}
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+function sourceLabel(s: IngredientSchema["nutritionSource"]): string {
+  switch (s) {
+    case "ai":
+      return "AI";
+    case "supplier":
+      return "Dodávateľ";
+    case "seed":
+      return "Seed";
+    default:
+      return "Manuálne";
+  }
+}
+
+function seedState(
+  initial: Ingredient | undefined,
+  _allergens: Allergen[]
+): FormState {
+  if (initial) {
+    return {
+      name: initial.name,
+      slug: initial.slug,
+      baseUnit: initial.baseUnit,
+      gramsPerPiece: initial.gramsPerPiece,
+      pricePerKgCents: initial.pricePerKgCents,
+      pricePerPieceCents: initial.pricePerPieceCents,
+      supplierName: initial.supplierName,
+      allergenCodes: initial.allergenCodes as AllergenCode[],
+      nutritionPer100: initial.nutritionPer100,
+      nutritionSource: initial.nutritionSource,
+      notes: initial.notes,
+      isActive: initial.isActive,
+    };
+  }
+  return {
+    name: "",
+    slug: "",
+    baseUnit: "g",
+    gramsPerPiece: null,
+    pricePerKgCents: 0,
+    pricePerPieceCents: null,
+    supplierName: null,
+    allergenCodes: [],
+    nutritionPer100: null,
+    nutritionSource: "manual",
+    notes: null,
+    isActive: true,
+  };
+}

--- a/src/features/ingredients/components/ingredients-table.tsx
+++ b/src/features/ingredients/components/ingredients-table.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { CircleAlertIcon } from "lucide-react";
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import type { Allergen } from "@/features/allergens/api/queries";
+import { AllergenChipStrip } from "@/features/allergens/components/allergen-picker";
+import type { AllergenCode } from "@/features/allergens/schema";
+import { cn } from "@/lib/utils";
+import type { IngredientListRow } from "../api/queries";
+import { formatBaseUnit, formatPricePerUnit } from "../lib/format";
+
+interface Props {
+  allergens: Allergen[];
+  ingredients: IngredientListRow[];
+}
+
+export function IngredientsTable({ ingredients, allergens }: Props) {
+  if (ingredients.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed p-8 text-center text-muted-foreground">
+        Žiadne suroviny. Vytvorte prvú surovinu tlačidlom „Nová surovina".
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <table className="w-full text-sm">
+        <thead className="border-b bg-muted/40 text-left text-muted-foreground text-xs">
+          <tr>
+            <th className="px-3 py-2 font-medium">Názov</th>
+            <th className="px-3 py-2 font-medium">Jednotka</th>
+            <th className="px-3 py-2 font-medium">Cena</th>
+            <th className="px-3 py-2 font-medium">Alergény</th>
+            <th className="px-3 py-2 font-medium">Stav</th>
+            <th className="px-3 py-2 font-medium">Upravené</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ingredients.map((i) => {
+            const noPrice =
+              (i.baseUnit === "g" &&
+                (i.pricePerKgCents === null || i.pricePerKgCents === 0)) ||
+              (i.baseUnit === "piece" &&
+                (i.pricePerPieceCents === null || i.pricePerPieceCents === 0));
+            const noNutrition = i.nutritionPer100 === null;
+            return (
+              <tr
+                className={cn(
+                  "border-b transition-colors hover:bg-muted/30",
+                  !i.isActive && "opacity-60"
+                )}
+                key={i.id}
+              >
+                <td className="px-3 py-2">
+                  <Link
+                    className="font-medium hover:underline"
+                    href={`/admin/ingredients/${i.id}` as never}
+                  >
+                    {i.name}
+                  </Link>
+                  {(noPrice || noNutrition) && (
+                    <div className="mt-0.5 flex gap-1 text-amber-600 text-xs dark:text-amber-400">
+                      {noPrice && (
+                        <span className="inline-flex items-center gap-0.5">
+                          <CircleAlertIcon className="size-3" />
+                          bez ceny
+                        </span>
+                      )}
+                      {noNutrition && (
+                        <span className="inline-flex items-center gap-0.5">
+                          <CircleAlertIcon className="size-3" />
+                          bez nutrície
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-muted-foreground">
+                  {formatBaseUnit(i.baseUnit)}
+                  {i.baseUnit === "piece" && i.gramsPerPiece ? (
+                    <span className="ml-1 text-xs">({i.gramsPerPiece}g)</span>
+                  ) : null}
+                </td>
+                <td className="px-3 py-2 font-mono text-xs">
+                  {formatPricePerUnit({
+                    baseUnit: i.baseUnit,
+                    pricePerKgCents: i.pricePerKgCents,
+                    pricePerPieceCents: i.pricePerPieceCents,
+                  })}
+                </td>
+                <td className="px-3 py-2">
+                  {i.allergenCodes.length > 0 ? (
+                    <AllergenChipStrip
+                      allergens={allergens}
+                      codes={i.allergenCodes as AllergenCode[]}
+                    />
+                  ) : (
+                    <span className="text-muted-foreground text-xs">—</span>
+                  )}
+                </td>
+                <td className="px-3 py-2">
+                  {i.isActive ? (
+                    <Badge variant="success">Aktívna</Badge>
+                  ) : (
+                    <Badge variant="secondary">Neaktívna</Badge>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-muted-foreground text-xs">
+                  {new Intl.DateTimeFormat("sk-SK", {
+                    dateStyle: "medium",
+                  }).format(new Date(i.updatedAt))}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/ingredients/components/nutrition-fields.tsx
+++ b/src/features/ingredients/components/nutrition-fields.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { Field, FieldContent, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import type { NutritionPer100Schema } from "../schema";
+
+type NullableNutrition = Partial<NutritionPer100Schema> | null;
+
+interface Props {
+  onChange: (next: NullableNutrition) => void;
+  readOnly?: boolean;
+  value: NullableNutrition;
+}
+
+const FIELDS: Array<{
+  key: keyof NutritionPer100Schema;
+  label: string;
+  unit: string;
+  step?: string;
+  indent?: boolean;
+}> = [
+  { key: "kcal", label: "Energia", unit: "kcal", step: "1" },
+  { key: "protein", label: "Bielkoviny", unit: "g", step: "0.1" },
+  { key: "fat", label: "Tuky", unit: "g", step: "0.1" },
+  {
+    key: "saturatedFat",
+    label: "z toho nasýtené",
+    unit: "g",
+    step: "0.1",
+    indent: true,
+  },
+  { key: "carbs", label: "Sacharidy", unit: "g", step: "0.1" },
+  {
+    key: "sugar",
+    label: "z toho cukry",
+    unit: "g",
+    step: "0.1",
+    indent: true,
+  },
+  { key: "fiber", label: "Vláknina", unit: "g", step: "0.1" },
+  { key: "salt", label: "Soľ", unit: "g", step: "0.01" },
+];
+
+/**
+ * Eight EU-mandatory nutrition fields per 100 g. Controlled component;
+ * parent owns the value. Returns null when all fields are empty,
+ * so the form can persist null when the admin clears everything.
+ */
+export function NutritionFields({ value, onChange, readOnly = false }: Props) {
+  const get = (key: keyof NutritionPer100Schema): string => {
+    const n = value?.[key];
+    return n === undefined || n === null ? "" : String(n);
+  };
+
+  const update = (key: keyof NutritionPer100Schema, raw: string) => {
+    const n = raw === "" ? null : Number(raw.replace(",", "."));
+    const next: Partial<NutritionPer100Schema> = {
+      ...(value ?? {}),
+      [key]: n === null || Number.isNaN(n) ? undefined : n,
+    };
+    // Drop empty fields. If everything is empty, return null.
+    const hasAny = Object.values(next).some(
+      (x) => typeof x === "number" && Number.isFinite(x)
+    );
+    onChange(hasAny ? next : null);
+  };
+
+  return (
+    <div className="grid gap-3 md:grid-cols-2">
+      {FIELDS.map((f) => (
+        <Field key={f.key} orientation="responsive">
+          <FieldContent>
+            <FieldLabel
+              className={f.indent ? "pl-4 text-muted-foreground" : ""}
+            >
+              {f.label}
+            </FieldLabel>
+          </FieldContent>
+          <div className="flex items-center gap-2">
+            <Input
+              className="w-24"
+              disabled={readOnly}
+              inputMode="decimal"
+              onChange={(e) => update(f.key, e.target.value)}
+              step={f.step}
+              type="number"
+              value={get(f.key)}
+            />
+            <span className="text-muted-foreground text-sm">{f.unit}</span>
+          </div>
+        </Field>
+      ))}
+    </div>
+  );
+}

--- a/src/features/ingredients/components/price-history-panel.tsx
+++ b/src/features/ingredients/components/price-history-panel.tsx
@@ -1,0 +1,77 @@
+import { format } from "date-fns";
+import { sk } from "date-fns/locale/sk";
+import type { IngredientBaseUnit } from "@/db/schema";
+import { formatCentsAsEur } from "../lib/price-conversion";
+
+interface PriceHistoryRow {
+  effectiveFrom: Date;
+  id: string;
+  notes: string | null;
+  pricePerKgCents: number | null;
+  pricePerPieceCents: number | null;
+  source: string;
+  supplierName: string | null;
+}
+
+interface Props {
+  baseUnit: IngredientBaseUnit;
+  history: PriceHistoryRow[];
+}
+
+/**
+ * Right-side panel on the ingredient detail page showing the last N
+ * price changes. List, not chart — chart is a nice-to-have for later.
+ */
+export function PriceHistoryPanel({ baseUnit, history }: Props) {
+  const unitLabel = baseUnit === "g" ? "/ kg" : "/ ks";
+
+  return (
+    <aside className="rounded-lg border bg-card">
+      <header className="border-b px-4 py-3">
+        <h3 className="font-semibold">História cien</h3>
+        <p className="text-muted-foreground text-xs">
+          Posledné zmeny ceny v {baseUnit === "g" ? "cents/kg" : "cents/ks"}.
+        </p>
+      </header>
+
+      {history.length === 0 ? (
+        <div className="p-4 text-muted-foreground text-sm">
+          Žiadne zmeny v histórii.
+        </div>
+      ) : (
+        <ol className="divide-y">
+          {history.map((row) => {
+            const cents =
+              baseUnit === "g" ? row.pricePerKgCents : row.pricePerPieceCents;
+            return (
+              <li className="space-y-1 px-4 py-3 text-sm" key={row.id}>
+                <div className="flex items-baseline justify-between gap-2">
+                  <span className="font-medium">
+                    {formatCentsAsEur(cents)} {unitLabel}
+                  </span>
+                  <span className="text-muted-foreground text-xs">
+                    {format(new Date(row.effectiveFrom), "d. LLL yyyy", {
+                      locale: sk,
+                    })}
+                  </span>
+                </div>
+                {(row.supplierName || row.source !== "manual") && (
+                  <p className="text-muted-foreground text-xs">
+                    {row.supplierName ?? ""}
+                    {row.supplierName && row.source !== "manual" ? " · " : ""}
+                    {row.source === "manual" ? "" : row.source}
+                  </p>
+                )}
+                {row.notes && (
+                  <p className="text-muted-foreground text-xs italic">
+                    {row.notes}
+                  </p>
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </aside>
+  );
+}

--- a/src/features/ingredients/components/price-input.tsx
+++ b/src/features/ingredients/components/price-input.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { IngredientBaseUnit } from "@/db/schema";
+import {
+  formatCentsAsEur,
+  MASS_INPUT_UNITS,
+  MASS_UNIT_LABELS,
+  type MassInputUnit,
+  normalizePriceInput,
+  PIECE_INPUT_UNITS,
+  PIECE_UNIT_LABELS,
+  type PieceInputUnit,
+  type PriceInputUnit,
+} from "../lib/price-conversion";
+
+interface Props {
+  baseUnit: IngredientBaseUnit;
+  description?: string;
+  label?: string;
+  onChange: (next: {
+    pricePerKgCents: number | null;
+    pricePerPieceCents: number | null;
+  }) => void;
+  pricePerKgCents: number | null;
+  pricePerPieceCents: number | null;
+}
+
+const DEFAULT_MASS_UNIT: MassInputUnit = "kg";
+const DEFAULT_PIECE_UNIT: PieceInputUnit = "1piece";
+
+/**
+ * Unit-aware price input. Admin types whatever amount + chooses a unit
+ * (kg / 500 g / 100 g / 1 piece / 12 pieces / ...). Component normalizes
+ * to canonical cents/kg or cents/piece on every keystroke and reports
+ * back via onChange. See docs/specs/_arc-overview.md §3.
+ */
+export function PriceInput({
+  baseUnit,
+  pricePerKgCents,
+  pricePerPieceCents,
+  onChange,
+  label = "Cena",
+  description,
+}: Props) {
+  // Track the displayed amount in EUR (string for input control)
+  // and the currently-selected input unit.
+  const [unit, setUnit] = useState<PriceInputUnit>(
+    baseUnit === "g" ? DEFAULT_MASS_UNIT : DEFAULT_PIECE_UNIT
+  );
+  const [amountStr, setAmountStr] = useState<string>(() =>
+    seedAmount(baseUnit, pricePerKgCents, pricePerPieceCents, unit)
+  );
+
+  // When baseUnit switches, reset the unit selector to a valid value.
+  useEffect(() => {
+    if (baseUnit === "g" && !isMassUnit(unit)) {
+      setUnit(DEFAULT_MASS_UNIT);
+    }
+    if (baseUnit === "piece" && isMassUnit(unit)) {
+      setUnit(DEFAULT_PIECE_UNIT);
+    }
+  }, [baseUnit, unit]);
+
+  const stored = baseUnit === "g" ? pricePerKgCents : pricePerPieceCents;
+  const storedLabel = baseUnit === "g" ? "c/kg" : "c/ks";
+
+  const handleAmount = (raw: string) => {
+    const filtered = raw.replace(/[^\d.,]/g, "").replace(",", ".");
+    setAmountStr(raw);
+    const amountEur = filtered === "" ? 0 : Number(filtered);
+    const { kg, piece } = normalizePriceInput({
+      amountEur,
+      inputUnit: unit,
+      baseUnit,
+    });
+    onChange({ pricePerKgCents: kg, pricePerPieceCents: piece });
+  };
+
+  const handleUnit = (nextUnit: string) => {
+    setUnit(nextUnit as PriceInputUnit);
+    const amountEur =
+      amountStr === "" ? 0 : Number(amountStr.replace(",", "."));
+    const { kg, piece } = normalizePriceInput({
+      amountEur,
+      inputUnit: nextUnit as PriceInputUnit,
+      baseUnit,
+    });
+    onChange({ pricePerKgCents: kg, pricePerPieceCents: piece });
+  };
+
+  const options =
+    baseUnit === "g"
+      ? MASS_INPUT_UNITS.map((u) => ({ value: u, label: MASS_UNIT_LABELS[u] }))
+      : PIECE_INPUT_UNITS.map((u) => ({
+          value: u,
+          label: PIECE_UNIT_LABELS[u],
+        }));
+
+  return (
+    <Field orientation="responsive">
+      <FieldContent>
+        <FieldLabel>{label}</FieldLabel>
+        {description && <FieldDescription>{description}</FieldDescription>}
+        <p className="text-muted-foreground text-xs">
+          Uložené ako:{" "}
+          <span className="font-mono">
+            {stored === null ? "—" : `${stored} ${storedLabel}`}
+          </span>
+          {stored !== null && baseUnit === "g" && (
+            <span className="ml-2">({formatCentsAsEur(stored)} / kg)</span>
+          )}
+          {stored !== null && baseUnit === "piece" && (
+            <span className="ml-2">({formatCentsAsEur(stored)} / ks)</span>
+          )}
+        </p>
+      </FieldContent>
+      <div className="flex items-center gap-2">
+        <Input
+          aria-label="Suma v eurách"
+          className="w-24"
+          inputMode="decimal"
+          onChange={(e) => handleAmount(e.target.value)}
+          placeholder="0,00"
+          value={amountStr}
+        />
+        <span className="text-muted-foreground">€ za</span>
+        <Select onValueChange={handleUnit} value={unit}>
+          <SelectTrigger className="w-32">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </Field>
+  );
+}
+
+function isMassUnit(u: PriceInputUnit): u is MassInputUnit {
+  return (MASS_INPUT_UNITS as readonly string[]).includes(u);
+}
+
+/**
+ * Seed the displayed amount string from the stored canonical value, so
+ * the form's initial render shows the right number+unit for the user.
+ */
+function seedAmount(
+  baseUnit: IngredientBaseUnit,
+  perKg: number | null,
+  perPiece: number | null,
+  unit: PriceInputUnit
+): string {
+  if (baseUnit === "g") {
+    if (perKg === null || perKg === 0) {
+      return "";
+    }
+    let cents: number;
+    switch (unit) {
+      case "500g":
+        cents = Math.round((perKg * 500) / 1000);
+        break;
+      case "100g":
+        cents = Math.round((perKg * 100) / 1000);
+        break;
+      default:
+        cents = perKg;
+    }
+    return (cents / 100).toFixed(2).replace(".", ",");
+  }
+  if (perPiece === null || perPiece === 0) {
+    return "";
+  }
+  let cents: number;
+  switch (unit) {
+    case "12pieces":
+      cents = perPiece * 12;
+      break;
+    case "10pieces":
+      cents = perPiece * 10;
+      break;
+    case "6pieces":
+      cents = perPiece * 6;
+      break;
+    default:
+      cents = perPiece;
+  }
+  return (cents / 100).toFixed(2).replace(".", ",");
+}

--- a/src/features/ingredients/lib/allergen-defaults.ts
+++ b/src/features/ingredients/lib/allergen-defaults.ts
@@ -1,0 +1,40 @@
+import type { AllergenCode } from "@/features/allergens/schema";
+
+/**
+ * Heuristic keyword-to-allergen mapping used to surface "Navrhnuté"
+ * chips under the ingredient name field. Cosmetic; admin always confirms.
+ */
+const RULES: Array<{ pattern: RegExp; codes: AllergenCode[] }> = [
+  { pattern: /múk[au]|chleb|otrub|pšenic|raž|spal|ovs/i, codes: ["gluten"] },
+  {
+    pattern:
+      /mlieko|smotan|maslo|jogurt|syr|tvaroh|cmar|mascarpone|niva|tvarôžky/i,
+    codes: ["milk"],
+  },
+  { pattern: /vajc/i, codes: ["eggs"] },
+  {
+    pattern: /mandl[ae]|orech|lieskov|kešu|piniov|para|pekan|pistaci/i,
+    codes: ["tree_nuts"],
+  },
+  { pattern: /araši/i, codes: ["peanuts"] },
+  { pattern: /sezam/i, codes: ["sesame"] },
+  { pattern: /sója|sójov|sojov/i, codes: ["soybeans"] },
+  { pattern: /horčic/i, codes: ["mustard"] },
+  { pattern: /zeler/i, codes: ["celery"] },
+  { pattern: /sušen[ée] (marhul|sliv|brusnic)/i, codes: ["sulphites"] },
+];
+
+export function suggestAllergens(name: string): AllergenCode[] {
+  if (!name) {
+    return [];
+  }
+  const out = new Set<AllergenCode>();
+  for (const rule of RULES) {
+    if (rule.pattern.test(name)) {
+      for (const c of rule.codes) {
+        out.add(c);
+      }
+    }
+  }
+  return [...out];
+}

--- a/src/features/ingredients/lib/anthropic.ts
+++ b/src/features/ingredients/lib/anthropic.ts
@@ -1,0 +1,44 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+/**
+ * Singleton Anthropic client. Returns null when ANTHROPIC_API_KEY is
+ * missing so the AI autofill action can fail gracefully without
+ * crashing import-time.
+ */
+export const anthropic: Anthropic | null = process.env.ANTHROPIC_API_KEY
+  ? new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+  : null;
+
+export const NUTRITION_SYSTEM_PROMPT = `Si nutričný odborník pre slovenskú pekáreň. Pre danú surovinu vráť presné nutričné hodnoty na 100 g vo formáte JSON.
+
+Hodnoty musia byť v základnej forme (suchá múka, surové vajce, atď.).
+Použi oficiálne zdroje: USDA FoodData Central, slovenské tabuľky zloženia potravín.
+Ak si nie si istý hodnotou, vráť 0 a "confidence": "low".
+
+Vráť výhradne JSON v presnom formáte (bez markdown bloku, bez komentárov):
+{
+  "kcal": number,
+  "protein": number,
+  "fat": number,
+  "saturatedFat": number,
+  "carbs": number,
+  "sugar": number,
+  "salt": number,
+  "fiber": number,
+  "confidence": "high" | "medium" | "low",
+  "source": string
+}`;
+
+const JSON_FENCE_RE = /```(?:json)?\s*([\s\S]*?)```/;
+
+/**
+ * Strip optional ```json fences and parse. The system prompt asks for
+ * raw JSON, but some Claude responses still wrap in fences.
+ */
+export function extractJsonBlock(raw: string): string {
+  const fenced = raw.match(JSON_FENCE_RE);
+  if (fenced?.[1]) {
+    return fenced[1].trim();
+  }
+  return raw.trim();
+}

--- a/src/features/ingredients/lib/format.ts
+++ b/src/features/ingredients/lib/format.ts
@@ -1,0 +1,56 @@
+import type { IngredientBaseUnit } from "@/db/schema";
+import { formatCentsAsEur } from "./price-conversion";
+
+/**
+ * Render the base unit chip on tables / detail views.
+ */
+export function formatBaseUnit(baseUnit: IngredientBaseUnit): string {
+  return baseUnit === "g" ? "g" : "ks";
+}
+
+/**
+ * Headline price label used by admin lists and the recipe builder.
+ * Shows both cents/kg and per-100g for mass ingredients (admins think in
+ * per-kg, customers think in per-100g — show both).
+ */
+export function formatPricePerUnit({
+  baseUnit,
+  pricePerKgCents,
+  pricePerPieceCents,
+}: {
+  baseUnit: IngredientBaseUnit;
+  pricePerKgCents: number | null;
+  pricePerPieceCents: number | null;
+}): string {
+  if (baseUnit === "piece") {
+    if (pricePerPieceCents === null) {
+      return "—";
+    }
+    return `${formatCentsAsEur(pricePerPieceCents)} / ks`;
+  }
+
+  if (pricePerKgCents === null) {
+    return "—";
+  }
+  const per100g = Math.round(pricePerKgCents / 10);
+  return `${formatCentsAsEur(pricePerKgCents)} / kg (${formatCentsAsEur(per100g)} / 100 g)`;
+}
+
+/**
+ * Compact label, for places where the full string is too long
+ * (e.g. recipe builder picker rows).
+ */
+export function formatPricePerUnitShort({
+  baseUnit,
+  pricePerKgCents,
+  pricePerPieceCents,
+}: {
+  baseUnit: IngredientBaseUnit;
+  pricePerKgCents: number | null;
+  pricePerPieceCents: number | null;
+}): string {
+  if (baseUnit === "piece") {
+    return `${formatCentsAsEur(pricePerPieceCents)} / ks`;
+  }
+  return `${formatCentsAsEur(pricePerKgCents)} / kg`;
+}

--- a/src/features/ingredients/lib/price-conversion.ts
+++ b/src/features/ingredients/lib/price-conversion.ts
@@ -1,0 +1,106 @@
+import type { IngredientBaseUnit } from "@/db/schema";
+
+/**
+ * Admin-facing units that can be entered in the price input. Internally
+ * everything normalizes to cents/kg (mass) or cents/piece (piece).
+ *
+ * See docs/specs/_arc-overview.md §3.
+ */
+export type MassInputUnit = "kg" | "500g" | "100g";
+export type PieceInputUnit = "1piece" | "12pieces" | "10pieces" | "6pieces";
+export type PriceInputUnit = MassInputUnit | PieceInputUnit;
+
+export const MASS_INPUT_UNITS: readonly MassInputUnit[] = [
+  "kg",
+  "500g",
+  "100g",
+];
+export const PIECE_INPUT_UNITS: readonly PieceInputUnit[] = [
+  "1piece",
+  "6pieces",
+  "10pieces",
+  "12pieces",
+];
+
+const MASS_UNIT_GRAMS: Record<MassInputUnit, number> = {
+  kg: 1000,
+  "500g": 500,
+  "100g": 100,
+};
+
+const PIECE_UNIT_COUNT: Record<PieceInputUnit, number> = {
+  "1piece": 1,
+  "6pieces": 6,
+  "10pieces": 10,
+  "12pieces": 12,
+};
+
+export const MASS_UNIT_LABELS: Record<MassInputUnit, string> = {
+  kg: "1 kg",
+  "500g": "500 g",
+  "100g": "100 g",
+};
+
+export const PIECE_UNIT_LABELS: Record<PieceInputUnit, string> = {
+  "1piece": "1 kus",
+  "6pieces": "6 kusov",
+  "10pieces": "10 kusov",
+  "12pieces": "12 kusov (tucet)",
+};
+
+export function isMassInputUnit(u: PriceInputUnit): u is MassInputUnit {
+  return (MASS_INPUT_UNITS as readonly string[]).includes(u);
+}
+
+/**
+ * Convert admin-entered amount (in euros, e.g. "4.00") + chosen input
+ * unit into canonical cents-per-kg or cents-per-piece. Returns null when
+ * the input is not a finite number.
+ */
+export function normalizePriceInput({
+  amountEur,
+  inputUnit,
+  baseUnit,
+}: {
+  amountEur: number;
+  inputUnit: PriceInputUnit;
+  baseUnit: IngredientBaseUnit;
+}): { kg: number | null; piece: number | null } {
+  if (!Number.isFinite(amountEur) || amountEur < 0) {
+    return { kg: null, piece: null };
+  }
+  const cents = Math.round(amountEur * 100);
+
+  if (baseUnit === "g") {
+    if (!isMassInputUnit(inputUnit)) {
+      return { kg: null, piece: null };
+    }
+    const grams = MASS_UNIT_GRAMS[inputUnit];
+    const perKg = Math.round((cents * 1000) / grams);
+    return { kg: perKg, piece: null };
+  }
+
+  if (isMassInputUnit(inputUnit)) {
+    return { kg: null, piece: null };
+  }
+  const count = PIECE_UNIT_COUNT[inputUnit];
+  const perPiece = Math.round(cents / count);
+  return { kg: null, piece: perPiece };
+}
+
+/**
+ * Format the canonical cents value back into "X,XX €" for the
+ * "Uložené ako" hint and read-only displays.
+ */
+export function formatCentsAsEur(cents: number | null | undefined): string {
+  if (cents === null || cents === undefined) {
+    return "—";
+  }
+  const eur = cents / 100;
+  return new Intl.NumberFormat("sk-SK", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(eur);
+}

--- a/src/features/ingredients/schema.ts
+++ b/src/features/ingredients/schema.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import {
+  INGREDIENT_BASE_UNITS,
+  INGREDIENT_NUTRITION_SOURCES,
+} from "@/db/schema";
+import { allergenCodeSchema } from "@/features/allergens/schema";
+
+/**
+ * Nutrition values per 100 g. EU 1169/2011 mandatory fields.
+ * Bounds chosen to be permissive (some seeds, oils have very high values).
+ */
+export const nutritionPer100Schema = z.object({
+  kcal: z.number().min(0).max(2000),
+  protein: z.number().min(0).max(100),
+  fat: z.number().min(0).max(100),
+  saturatedFat: z.number().min(0).max(100),
+  carbs: z.number().min(0).max(100),
+  sugar: z.number().min(0).max(100),
+  salt: z.number().min(0).max(100),
+  fiber: z.number().min(0).max(100),
+});
+
+export type NutritionPer100Schema = z.infer<typeof nutritionPer100Schema>;
+
+export const ingredientSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(1, "Názov je povinný")
+      .max(100, "Názov je príliš dlhý"),
+    slug: z.string().trim().min(1).max(120),
+    baseUnit: z.enum(INGREDIENT_BASE_UNITS),
+    gramsPerPiece: z.number().int().positive().nullable(),
+    pricePerKgCents: z.number().int().min(0).nullable(),
+    pricePerPieceCents: z.number().int().min(0).nullable(),
+    supplierName: z.string().trim().max(100).nullable(),
+    allergenCodes: z.array(allergenCodeSchema),
+    nutritionPer100: nutritionPer100Schema.nullable(),
+    nutritionSource: z.enum(INGREDIENT_NUTRITION_SOURCES),
+    notes: z.string().trim().max(2000).nullable(),
+    isActive: z.boolean(),
+  })
+  .refine(
+    (v) =>
+      v.baseUnit !== "piece" ||
+      (v.gramsPerPiece !== null && v.gramsPerPiece > 0),
+    {
+      message: "Pri jednotke 'kus' musí byť zadaná hmotnosť za kus",
+      path: ["gramsPerPiece"],
+    }
+  )
+  .refine(
+    (v) =>
+      (v.baseUnit === "g" &&
+        v.pricePerKgCents !== null &&
+        v.pricePerPieceCents === null) ||
+      (v.baseUnit === "piece" &&
+        v.pricePerPieceCents !== null &&
+        v.pricePerKgCents === null),
+    {
+      message: "Cena musí byť zadaná v jednotke zodpovedajúcej baseUnit",
+      path: ["pricePerKgCents"],
+    }
+  );
+
+export type IngredientSchema = z.infer<typeof ingredientSchema>;
+
+export const updateIngredientSchema = z.object({
+  id: z.string().min(1),
+  data: ingredientSchema,
+});
+
+export type UpdateIngredientSchema = z.infer<typeof updateIngredientSchema>;
+
+/**
+ * Shape returned by the AI nutrition autofill action. The AI returns
+ * the 8 nutrition values plus a confidence level and a source citation.
+ */
+export const aiNutritionSuggestionSchema = nutritionPer100Schema.extend({
+  confidence: z.enum(["high", "medium", "low"]),
+  source: z.string().max(200),
+});
+
+export type AiNutritionSuggestion = z.infer<typeof aiNutritionSuggestionSchema>;

--- a/src/features/nutrition/components/nutrition-table.tsx
+++ b/src/features/nutrition/components/nutrition-table.tsx
@@ -1,0 +1,84 @@
+import type { NutritionPer100Schema } from "@/features/ingredients/schema";
+import { kJFromKcal } from "@/features/recipes/lib/nutrition-math";
+
+interface Props {
+  className?: string;
+  nutrition: NutritionPer100Schema | null;
+  source: "computed" | "override" | "none";
+}
+
+/**
+ * EU 1169/2011 nutrition declaration per 100 g. Slovak labels + decimal
+ * comma formatting. Returns null when no nutrition data is available —
+ * silence is the right UX for products without recipe + override.
+ */
+export function NutritionTable({ nutrition, source, className }: Props) {
+  if (!nutrition || source === "none") {
+    return null;
+  }
+
+  const kJ = kJFromKcal(nutrition.kcal);
+
+  return (
+    <section className={className}>
+      <h3 className="mb-3 font-semibold text-sm tracking-tight">
+        Nutričné hodnoty na 100 g
+      </h3>
+      <table className="w-full border-collapse text-sm">
+        <tbody>
+          <Row label="Energia" value={`${kJ} kJ / ${nutrition.kcal} kcal`} />
+          <Row label="Tuky" value={`${formatG(nutrition.fat)} g`} />
+          <Row
+            indent
+            label="z toho nasýtené mastné kyseliny"
+            value={`${formatG(nutrition.saturatedFat)} g`}
+          />
+          <Row label="Sacharidy" value={`${formatG(nutrition.carbs)} g`} />
+          <Row
+            indent
+            label="z toho cukry"
+            value={`${formatG(nutrition.sugar)} g`}
+          />
+          <Row label="Vláknina" value={`${formatG(nutrition.fiber)} g`} />
+          <Row label="Bielkoviny" value={`${formatG(nutrition.protein)} g`} />
+          <Row label="Soľ" value={`${formatSalt(nutrition.salt)} g`} />
+        </tbody>
+      </table>
+      <p className="mt-2 text-muted-foreground text-xs">
+        {source === "override"
+          ? "Hodnoty zadané manuálne."
+          : "Hodnoty vypočítané z receptu."}
+      </p>
+    </section>
+  );
+}
+
+function Row({
+  label,
+  value,
+  indent,
+}: {
+  label: string;
+  value: string;
+  indent?: boolean;
+}) {
+  return (
+    <tr className="border-b last:border-b-0">
+      <td
+        className={
+          indent ? "py-1.5 pl-4 text-muted-foreground" : "py-1.5 font-medium"
+        }
+      >
+        {label}
+      </td>
+      <td className="py-1.5 text-right tabular-nums">{value}</td>
+    </tr>
+  );
+}
+
+function formatG(n: number): string {
+  return n.toFixed(1).replace(".", ",");
+}
+function formatSalt(n: number): string {
+  return n.toFixed(2).replace(".", ",");
+}

--- a/src/features/orders/actions/create-b2c-order.ts
+++ b/src/features/orders/actions/create-b2c-order.ts
@@ -125,6 +125,7 @@ export async function createB2COrder(data: {
     const { orderId, orderNumber, userId, totalCents, itemCount } = result.data;
 
     updateTag("orders");
+    updateTag("reports");
 
     // Clear cart only after confirmed pipeline success
     await clearCartAfterOrder().catch((err) => {

--- a/src/features/orders/actions/internal.ts
+++ b/src/features/orders/actions/internal.ts
@@ -16,6 +16,8 @@ import {
   getCart,
 } from "@/features/cart/cookies";
 import { userInfoSchema } from "@/features/checkout/schema";
+import { getResolverContext } from "@/features/recipes/api/queries";
+import { resolveRecipeCost } from "@/features/recipes/lib/cost-resolver";
 import { sendEmail } from "@/lib/email";
 import { createOrderNumber, createPrefixedId } from "@/lib/ids";
 import { log } from "@/lib/logger";
@@ -28,6 +30,12 @@ export interface OrderItemData {
   productId: string;
   productSnapshot: ProductSnapshot;
   quantity: number;
+  /**
+   * Computed cost-per-unit at order creation (Phase C). Nullable when
+   * the product has no recipe or the resolver fails — never block
+   * checkout to track cost.
+   */
+  unitCostCents: number | null;
 }
 
 export interface GuestCustomerInfo {
@@ -104,6 +112,8 @@ export async function buildOrderItems(
       ? await getEffectivePrices({ productPrices, priceTierId })
       : new Map<string, number>();
 
+  const productCosts = await computeProductCosts(activeProducts);
+
   return cartItems.flatMap((item) => {
     const product = activeProducts.find((p) => p.id === item.productId);
     if (!product) {
@@ -125,9 +135,51 @@ export async function buildOrderItems(
         },
         price: effectivePrice,
         quantity: item.qty,
+        unitCostCents: productCosts.get(product.id) ?? null,
       },
     ];
   });
+}
+
+/**
+ * Resolve cost-per-unit for each product that has a recipe. Failures
+ * are logged and the product gets null — checkout never breaks because
+ * of cost tracking.
+ */
+async function computeProductCosts(
+  activeProducts: Array<{ id: string; recipeId: string | null }>
+): Promise<Map<string, number | null>> {
+  const out = new Map<string, number | null>();
+  const productsWithRecipe = activeProducts.filter((p) => p.recipeId);
+  if (productsWithRecipe.length === 0) {
+    return out;
+  }
+
+  try {
+    const ctx = await getResolverContext({ includeDrafts: false });
+    for (const p of productsWithRecipe) {
+      if (!p.recipeId) {
+        continue;
+      }
+      try {
+        const resolved = resolveRecipeCost(p.recipeId, ctx);
+        out.set(p.id, resolved.costPerUnitCents);
+      } catch (err) {
+        log.orders.warn(
+          { err, productId: p.id, recipeId: p.recipeId },
+          "Cost snapshot failed; storing null"
+        );
+        out.set(p.id, null);
+      }
+    }
+  } catch (err) {
+    log.orders.warn(
+      { err },
+      "Resolver context unavailable; all order items get null cost"
+    );
+  }
+
+  return out;
 }
 
 /**
@@ -201,7 +253,7 @@ export async function persistOrder(params: PersistOrderParams): Promise<{
 
     const itemValues = params.orderItemsData.map(
       (item) =>
-        sql`(${item.productId}::text, ${JSON.stringify(item.productSnapshot)}::jsonb, ${item.quantity}::integer, ${item.price}::integer)`
+        sql`(${item.productId}::text, ${JSON.stringify(item.productSnapshot)}::jsonb, ${item.quantity}::integer, ${item.price}::integer, ${item.unitCostCents}::integer)`
     );
 
     const query = sql`
@@ -225,10 +277,10 @@ export async function persistOrder(params: PersistOrderParams): Promise<{
       new_items AS (
         INSERT INTO ${orderItems} (
           order_id, product_id,
-          product_snapshot, quantity, price
+          product_snapshot, quantity, price, unit_cost_cents
         )
-        SELECT new_order.id, v.product_id, v.snapshot, v.qty, v.price
-        FROM new_order, (VALUES ${sql.join(itemValues, sql`, `)}) AS v(product_id, snapshot, qty, price)
+        SELECT new_order.id, v.product_id, v.snapshot, v.qty, v.price, v.unit_cost
+        FROM new_order, (VALUES ${sql.join(itemValues, sql`, `)}) AS v(product_id, snapshot, qty, price, unit_cost)
         RETURNING 1
       ),
       new_event AS (

--- a/src/features/products/api/allergen-drift.ts
+++ b/src/features/products/api/allergen-drift.ts
@@ -1,0 +1,101 @@
+import "server-only";
+
+import { isNotNull } from "drizzle-orm";
+import { cacheLife, cacheTag } from "next/cache";
+import { db } from "@/db";
+import { products } from "@/db/schema";
+import type { AllergenCode } from "@/features/allergens/schema";
+import { getResolverContext } from "@/features/recipes/api/queries";
+import { resolveRecipeCost } from "@/features/recipes/lib/cost-resolver";
+
+export interface DriftRow {
+  added: AllergenCode[];
+  derivedCodes: AllergenCode[];
+  manualCodes: AllergenCode[];
+  productId: string;
+  productName: string;
+  productSlug: string;
+  recipeId: string;
+  removed: AllergenCode[];
+  resolverError: string | null;
+}
+
+interface DriftResult {
+  items: DriftRow[];
+  total: number;
+}
+
+/**
+ * Diff between manual products.allergenCodes and recipe-derived allergens
+ * for products with a linked recipe. Paginated to stay fast on growing
+ * catalogs. Read-only diagnostic.
+ */
+export async function getAllergenDrift(
+  opts: { offset?: number; limit?: number } = {}
+): Promise<DriftResult> {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("products", "recipes", "ingredients", "allergens-drift");
+
+  const offset = opts.offset ?? 0;
+  const limit = Math.min(opts.limit ?? 50, 100);
+
+  const [page, ctx] = await Promise.all([
+    db
+      .select({
+        id: products.id,
+        name: products.name,
+        slug: products.slug,
+        recipeId: products.recipeId,
+        allergenCodes: products.allergenCodes,
+      })
+      .from(products)
+      .where(isNotNull(products.recipeId))
+      .limit(limit)
+      .offset(offset),
+    getResolverContext({ includeDrafts: false }),
+  ]);
+
+  const totalRow = await db
+    .select({ count: products.id })
+    .from(products)
+    .where(isNotNull(products.recipeId));
+  const total = totalRow.length;
+
+  const items: DriftRow[] = [];
+  for (const p of page) {
+    if (!p.recipeId) {
+      continue;
+    }
+    const manual = (p.allergenCodes as AllergenCode[]).slice().sort();
+    let derived: AllergenCode[] = [];
+    let resolverError: string | null = null;
+    try {
+      const resolved = resolveRecipeCost(p.recipeId, ctx);
+      derived = resolved.allergenCodes.slice().sort();
+    } catch (err) {
+      resolverError = err instanceof Error ? err.message : "Unknown error";
+    }
+
+    const manualSet = new Set(manual);
+    const derivedSet = new Set(derived);
+    const added = derived.filter((c) => !manualSet.has(c));
+    const removed = manual.filter((c) => !derivedSet.has(c));
+
+    if (added.length + removed.length > 0 || resolverError) {
+      items.push({
+        productId: p.id,
+        productName: p.name,
+        productSlug: p.slug,
+        recipeId: p.recipeId,
+        manualCodes: manual,
+        derivedCodes: derived,
+        added,
+        removed,
+        resolverError,
+      });
+    }
+  }
+
+  return { items, total };
+}

--- a/src/features/products/api/product-display.ts
+++ b/src/features/products/api/product-display.ts
@@ -1,0 +1,103 @@
+import "server-only";
+
+import { eq } from "drizzle-orm";
+import { cacheLife, cacheTag } from "next/cache";
+import { db } from "@/db";
+import { products } from "@/db/schema";
+import type { AllergenCode } from "@/features/allergens/schema";
+import type { NutritionPer100Schema } from "@/features/ingredients/schema";
+import { getResolverContext } from "@/features/recipes/api/queries";
+import { resolveRecipeCost } from "@/features/recipes/lib/cost-resolver";
+
+export interface ProductDisplay {
+  allergenCodes: AllergenCode[];
+  allergenSource: "derived" | "manual";
+  nutrition: NutritionPer100Schema | null;
+  nutritionIncomplete: boolean;
+  nutritionSource: "computed" | "override" | "none";
+}
+
+/**
+ * Consolidated PDP data source for allergens + nutrition.
+ *
+ * Resolution rules:
+ * - Allergens: derived from recipe when the product has one and the
+ *   resolver succeeds; otherwise fall back to the manual
+ *   products.allergenCodes column (Phase A).
+ * - Nutrition: override (jsonb on products) wins if set; otherwise
+ *   derived from recipe; otherwise null (PDP hides the section).
+ */
+export async function getDerivedProductDisplay(
+  productId: string
+): Promise<ProductDisplay> {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("products", `product-${productId}`, "recipes", "ingredients");
+
+  const row = await db
+    .select({
+      id: products.id,
+      allergenCodes: products.allergenCodes,
+      recipeId: products.recipeId,
+      nutritionOverride: products.nutritionOverride,
+    })
+    .from(products)
+    .where(eq(products.id, productId))
+    .limit(1);
+  if (!row[0]) {
+    return {
+      allergenCodes: [],
+      allergenSource: "manual",
+      nutrition: null,
+      nutritionSource: "none",
+      nutritionIncomplete: false,
+    };
+  }
+
+  const product = row[0];
+  const manualAllergens = product.allergenCodes as AllergenCode[];
+  const override = product.nutritionOverride as NutritionPer100Schema | null;
+
+  // If admin set a nutrition override, use it verbatim. Allergens still
+  // try to derive from the recipe.
+  let allergenCodes = manualAllergens;
+  let allergenSource: "derived" | "manual" = "manual";
+  let computedNutrition: NutritionPer100Schema | null = null;
+  let nutritionIncomplete = false;
+
+  if (product.recipeId) {
+    try {
+      const ctx = await getResolverContext({ includeDrafts: false });
+      const resolved = resolveRecipeCost(product.recipeId, ctx);
+      allergenCodes = resolved.allergenCodes;
+      allergenSource = "derived";
+      computedNutrition = resolved.nutritionPer100;
+      nutritionIncomplete = resolved.nutritionIncomplete;
+    } catch {
+      // Resolver threw — fall back to manual allergens, hide nutrition.
+      allergenCodes = manualAllergens;
+      allergenSource = "manual";
+    }
+  }
+
+  let nutrition: NutritionPer100Schema | null;
+  let nutritionSource: "computed" | "override" | "none";
+  if (override) {
+    nutrition = override;
+    nutritionSource = "override";
+  } else if (computedNutrition && !nutritionIncomplete) {
+    nutrition = computedNutrition;
+    nutritionSource = "computed";
+  } else {
+    nutrition = null;
+    nutritionSource = "none";
+  }
+
+  return {
+    allergenCodes,
+    allergenSource,
+    nutrition,
+    nutritionSource,
+    nutritionIncomplete,
+  };
+}

--- a/src/features/products/schema.ts
+++ b/src/features/products/schema.ts
@@ -1,5 +1,6 @@
 import type { JSONContent } from "@tiptap/react";
 import z from "zod";
+import { allergenCodeSchema } from "@/features/allergens/schema";
 import { MAX_STRING_LENGTH } from "@/lib/constants";
 
 const PRODUCT_STATUSES = ["draft", "active", "sold", "archived"] as const;
@@ -21,6 +22,7 @@ export const updateProductSchema = z.object({
   ...productSchema.shape,
   categoryId: z.string().nullable(),
   imageId: z.string().nullable(),
+  allergenCodes: z.array(allergenCodeSchema),
 });
 
 export type UpdateProductSchema = z.infer<typeof updateProductSchema>;

--- a/src/features/products/schema.ts
+++ b/src/features/products/schema.ts
@@ -1,6 +1,7 @@
 import type { JSONContent } from "@tiptap/react";
 import z from "zod";
 import { allergenCodeSchema } from "@/features/allergens/schema";
+import { nutritionPer100Schema } from "@/features/ingredients/schema";
 import { MAX_STRING_LENGTH } from "@/lib/constants";
 
 const PRODUCT_STATUSES = ["draft", "active", "sold", "archived"] as const;
@@ -23,6 +24,8 @@ export const updateProductSchema = z.object({
   categoryId: z.string().nullable(),
   imageId: z.string().nullable(),
   allergenCodes: z.array(allergenCodeSchema),
+  /** Phase D: optional manual override; null = derive from recipe (or hide). */
+  nutritionOverride: nutritionPer100Schema.nullable(),
 });
 
 export type UpdateProductSchema = z.infer<typeof updateProductSchema>;

--- a/src/features/recipes/api/actions.ts
+++ b/src/features/recipes/api/actions.ts
@@ -1,0 +1,510 @@
+"use server";
+
+import { eq, sql } from "drizzle-orm";
+import { updateTag } from "next/cache";
+import { redirect } from "next/navigation";
+import { db } from "@/db";
+import { products, recipeItems, recipes } from "@/db/schema";
+import { draftSlug } from "@/db/utils";
+import { requireRecipeEdit } from "@/lib/auth/guards";
+import { log } from "@/lib/logger";
+import { canAddSubRecipe, resolveRecipeCost } from "../lib/cost-resolver";
+import {
+  type AddRecipeItemSchema,
+  addRecipeItemSchema,
+  type LinkProductRecipeSchema,
+  linkProductRecipeSchema,
+  type RecipeHeaderSchema,
+  recipeHeaderSchema,
+  removeRecipeItemSchema,
+  reorderRecipeItemsSchema,
+  type UpdateRecipeItemSchema,
+  updateRecipeItemSchema,
+} from "../schema";
+import {
+  getRecipeDependents,
+  getRecipeGraph,
+  getResolverContext,
+} from "./queries";
+
+type ActionResult<T = void> =
+  | (T extends void ? { success: true } : { success: true } & T)
+  | { success: false; error: string };
+
+function invalidate(recipeId?: string, productId?: string) {
+  updateTag("recipes");
+  updateTag("products");
+  updateTag("reports");
+  if (recipeId) {
+    updateTag(`recipe-${recipeId}`);
+  }
+  if (productId) {
+    updateTag(`product-${productId}`);
+  }
+}
+
+// ---------------- Recipe header CRUD ----------------
+
+/**
+ * Create a draft recipe + redirect to its edit page.
+ * Used by the "Nový recept" button on /admin/recipes and by the
+ * "Vytvoriť recept" CTA inside the product Recept tab.
+ */
+export async function createRecipeAction({
+  kind,
+  productId,
+}: {
+  kind?: "product" | "sub_recipe";
+  productId?: string | null;
+}) {
+  await requireRecipeEdit();
+
+  const [created] = await db
+    .insert(recipes)
+    .values({ kind: kind ?? "product" })
+    .returning({ id: recipes.id });
+
+  // Optionally link to a product (e.g. when called from the product page)
+  if (productId) {
+    await db
+      .update(products)
+      .set({ recipeId: created.id })
+      .where(eq(products.id, productId));
+  }
+
+  invalidate(created.id, productId ?? undefined);
+  redirect(`/admin/recipes/${created.id}`);
+}
+
+export async function updateRecipeHeaderAction({
+  id,
+  data,
+}: {
+  id: string;
+  data: RecipeHeaderSchema;
+}): Promise<ActionResult> {
+  await requireRecipeEdit();
+  const parsed = recipeHeaderSchema.safeParse(data);
+  if (!parsed.success) {
+    return { success: false, error: "Neplatné údaje" };
+  }
+  const v = parsed.data;
+
+  try {
+    // If admin flips kind from product -> sub_recipe, unlink any product
+    // that points to this recipe (sub-recipes aren't standalone products).
+    if (v.kind === "sub_recipe") {
+      await db
+        .update(products)
+        .set({ recipeId: null })
+        .where(eq(products.recipeId, id));
+    }
+    await db
+      .update(recipes)
+      .set({
+        name: v.name,
+        slug: v.slug || draftSlug(v.name),
+        kind: v.kind,
+        status: v.status,
+        batchYieldUnits: v.batchYieldUnits,
+        batchYieldGrams: v.batchYieldGrams,
+        yieldLossPercent: v.yieldLossPercent,
+        notes: v.notes,
+      })
+      .where(eq(recipes.id, id));
+    invalidate(id);
+    return { success: true };
+  } catch (err) {
+    log.recipes.error({ err, recipeId: id }, "Update recipe header failed");
+    return { success: false, error: "Uloženie zlyhalo" };
+  }
+}
+
+export async function deleteRecipeAction({
+  id,
+}: {
+  id: string;
+}): Promise<ActionResult> {
+  await requireRecipeEdit();
+
+  // Block deletion if any product or parent recipe references this.
+  const deps = await getRecipeDependents(id);
+  if (deps.products.length > 0 || deps.parentRecipes.length > 0) {
+    return {
+      success: false,
+      error: `Recept je použitý (${deps.products.length} produktov, ${deps.parentRecipes.length} subreceptov).`,
+    };
+  }
+
+  try {
+    await db.delete(recipes).where(eq(recipes.id, id));
+    invalidate(id);
+    return { success: true };
+  } catch (err) {
+    log.recipes.error({ err, recipeId: id }, "Delete recipe failed");
+    return { success: false, error: "Odstránenie zlyhalo" };
+  }
+}
+
+/**
+ * Duplicate a recipe into a fresh draft, copy all items. The "5 recipes
+ * in and you're reusing" workflow — promoted to MVP per the spike.
+ */
+export async function duplicateRecipeAction({ id }: { id: string }) {
+  await requireRecipeEdit();
+
+  const source = await db
+    .select()
+    .from(recipes)
+    .where(eq(recipes.id, id))
+    .limit(1);
+  if (!source[0]) {
+    return { success: false, error: "Recept neexistuje" } as const;
+  }
+  const src = source[0];
+
+  const items = await db
+    .select()
+    .from(recipeItems)
+    .where(eq(recipeItems.recipeId, id));
+
+  const [copy] = await db
+    .insert(recipes)
+    .values({
+      name: `${src.name} (kópia)`,
+      slug: draftSlug(`${src.name} kopia`),
+      kind: src.kind,
+      status: "draft",
+      batchYieldUnits: src.batchYieldUnits,
+      batchYieldGrams: src.batchYieldGrams,
+      yieldLossPercent: src.yieldLossPercent,
+      notes: src.notes,
+    })
+    .returning({ id: recipes.id });
+
+  if (items.length > 0) {
+    await db.insert(recipeItems).values(
+      items.map((it) => ({
+        recipeId: copy.id,
+        ingredientId: it.ingredientId,
+        subRecipeId: it.subRecipeId,
+        quantityBaseUnit: it.quantityBaseUnit,
+        sortOrder: it.sortOrder,
+        notes: it.notes,
+      }))
+    );
+  }
+
+  invalidate(copy.id);
+  redirect(`/admin/recipes/${copy.id}`);
+}
+
+export async function publishRecipeAction({
+  id,
+}: {
+  id: string;
+}): Promise<ActionResult> {
+  await requireRecipeEdit();
+
+  // Validate the recipe resolves cleanly before allowing publish.
+  const ctx = await getResolverContext({ includeDrafts: true });
+  try {
+    resolveRecipeCost(id, ctx);
+  } catch (err) {
+    log.recipes.warn(
+      { err, recipeId: id },
+      "Recipe publish blocked by resolver"
+    );
+    return {
+      success: false,
+      error: "Recept nemožno publikovať — chyba pri výpočte nákladov.",
+    };
+  }
+
+  await db
+    .update(recipes)
+    .set({ status: "published" })
+    .where(eq(recipes.id, id));
+  invalidate(id);
+  return { success: true };
+}
+
+// ---------------- Recipe items ----------------
+
+export async function addRecipeItemAction(
+  input: AddRecipeItemSchema
+): Promise<ActionResult<{ itemId: string }>> {
+  await requireRecipeEdit();
+  const parsed = addRecipeItemSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: "Neplatné údaje" };
+  }
+  const v = parsed.data;
+
+  // Cycle/depth pre-check for sub-recipes
+  if (v.subRecipeId) {
+    const graph = await getRecipeGraph();
+    const check = canAddSubRecipe(v.recipeId, v.subRecipeId, graph);
+    if (!check.ok) {
+      return { success: false, error: canAddSubRecipeMessage(check.reason) };
+    }
+  }
+
+  // sortOrder = max+1
+  const max = await db
+    .select({ max: sql<number>`COALESCE(MAX(${recipeItems.sortOrder}), -1)` })
+    .from(recipeItems)
+    .where(eq(recipeItems.recipeId, v.recipeId));
+  const sortOrder = (max[0]?.max ?? -1) + 1;
+
+  try {
+    const [item] = await db
+      .insert(recipeItems)
+      .values({
+        recipeId: v.recipeId,
+        ingredientId: v.ingredientId,
+        subRecipeId: v.subRecipeId,
+        quantityBaseUnit: v.quantityBaseUnit,
+        sortOrder,
+      })
+      .returning({ id: recipeItems.id });
+    invalidate(v.recipeId);
+    return { success: true, itemId: item.id };
+  } catch (err) {
+    log.recipes.error({ err, recipeId: v.recipeId }, "Add recipe item failed");
+    return { success: false, error: "Pridanie zlyhalo" };
+  }
+}
+
+export async function bulkAddItemsFromRecipeAction({
+  targetRecipeId,
+  sourceRecipeId,
+}: {
+  targetRecipeId: string;
+  sourceRecipeId: string;
+}): Promise<ActionResult<{ added: number; skipped: number }>> {
+  await requireRecipeEdit();
+  if (targetRecipeId === sourceRecipeId) {
+    return { success: false, error: "Zdrojový a cieľový recept sú rovnaké" };
+  }
+
+  const [sourceItems, existing] = await Promise.all([
+    db
+      .select()
+      .from(recipeItems)
+      .where(eq(recipeItems.recipeId, sourceRecipeId))
+      .orderBy(recipeItems.sortOrder),
+    db
+      .select({
+        ingredientId: recipeItems.ingredientId,
+        subRecipeId: recipeItems.subRecipeId,
+      })
+      .from(recipeItems)
+      .where(eq(recipeItems.recipeId, targetRecipeId)),
+  ]);
+
+  const existingIngredients = new Set(
+    existing.map((e) => e.ingredientId).filter(Boolean) as string[]
+  );
+  const existingSubRecipes = new Set(
+    existing.map((e) => e.subRecipeId).filter(Boolean) as string[]
+  );
+
+  // Cycle/depth check for any sub-recipe items we'd import
+  const graph = await getRecipeGraph();
+
+  const maxRow = await db
+    .select({ max: sql<number>`COALESCE(MAX(${recipeItems.sortOrder}), -1)` })
+    .from(recipeItems)
+    .where(eq(recipeItems.recipeId, targetRecipeId));
+  let sortOrder = (maxRow[0]?.max ?? -1) + 1;
+
+  const toInsert: Array<{
+    recipeId: string;
+    ingredientId: string | null;
+    subRecipeId: string | null;
+    quantityBaseUnit: number;
+    sortOrder: number;
+  }> = [];
+  let skipped = 0;
+
+  for (const it of sourceItems) {
+    if (it.ingredientId && existingIngredients.has(it.ingredientId)) {
+      skipped++;
+      continue;
+    }
+    if (it.subRecipeId) {
+      if (existingSubRecipes.has(it.subRecipeId)) {
+        skipped++;
+        continue;
+      }
+      const check = canAddSubRecipe(targetRecipeId, it.subRecipeId, graph);
+      if (!check.ok) {
+        skipped++;
+        continue;
+      }
+    }
+    toInsert.push({
+      recipeId: targetRecipeId,
+      ingredientId: it.ingredientId,
+      subRecipeId: it.subRecipeId,
+      quantityBaseUnit: it.quantityBaseUnit,
+      sortOrder: sortOrder++,
+    });
+  }
+
+  if (toInsert.length > 0) {
+    await db.insert(recipeItems).values(toInsert);
+  }
+  invalidate(targetRecipeId);
+  return { success: true, added: toInsert.length, skipped };
+}
+
+export async function updateRecipeItemAction(
+  input: UpdateRecipeItemSchema
+): Promise<ActionResult> {
+  await requireRecipeEdit();
+  const parsed = updateRecipeItemSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: "Neplatné údaje" };
+  }
+  const v = parsed.data;
+
+  const row = await db
+    .select({ recipeId: recipeItems.recipeId })
+    .from(recipeItems)
+    .where(eq(recipeItems.id, v.itemId))
+    .limit(1);
+  if (!row[0]) {
+    return { success: false, error: "Položka neexistuje" };
+  }
+
+  try {
+    await db
+      .update(recipeItems)
+      .set({ quantityBaseUnit: v.quantityBaseUnit })
+      .where(eq(recipeItems.id, v.itemId));
+    invalidate(row[0].recipeId);
+    return { success: true };
+  } catch (err) {
+    log.recipes.error({ err, itemId: v.itemId }, "Update recipe item failed");
+    return { success: false, error: "Uloženie zlyhalo" };
+  }
+}
+
+export async function removeRecipeItemAction(input: {
+  itemId: string;
+}): Promise<ActionResult> {
+  await requireRecipeEdit();
+  const parsed = removeRecipeItemSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: "Neplatné údaje" };
+  }
+
+  const row = await db
+    .select({ recipeId: recipeItems.recipeId })
+    .from(recipeItems)
+    .where(eq(recipeItems.id, parsed.data.itemId))
+    .limit(1);
+  if (!row[0]) {
+    return { success: true };
+  }
+
+  try {
+    await db.delete(recipeItems).where(eq(recipeItems.id, parsed.data.itemId));
+    invalidate(row[0].recipeId);
+    return { success: true };
+  } catch (err) {
+    log.recipes.error(
+      { err, itemId: parsed.data.itemId },
+      "Remove recipe item failed"
+    );
+    return { success: false, error: "Odstránenie zlyhalo" };
+  }
+}
+
+export async function reorderRecipeItemsAction(input: {
+  recipeId: string;
+  orderedItemIds: string[];
+}): Promise<ActionResult> {
+  await requireRecipeEdit();
+  const parsed = reorderRecipeItemsSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: "Neplatné údaje" };
+  }
+  const v = parsed.data;
+
+  // Sequential UPDATEs — Neon HTTP doesn't do transactions. Order
+  // doesn't matter for correctness (each row's sortOrder is independent).
+  try {
+    for (let i = 0; i < v.orderedItemIds.length; i++) {
+      await db
+        .update(recipeItems)
+        .set({ sortOrder: i })
+        .where(eq(recipeItems.id, v.orderedItemIds[i]));
+    }
+    invalidate(v.recipeId);
+    return { success: true };
+  } catch (err) {
+    log.recipes.error(
+      { err, recipeId: v.recipeId },
+      "Reorder recipe items failed"
+    );
+    return { success: false, error: "Zmena poradia zlyhala" };
+  }
+}
+
+// ---------------- Product <-> recipe link ----------------
+
+export async function linkProductRecipeAction(
+  input: LinkProductRecipeSchema
+): Promise<ActionResult> {
+  await requireRecipeEdit();
+  const parsed = linkProductRecipeSchema.safeParse(input);
+  if (!parsed.success) {
+    return { success: false, error: "Neplatné údaje" };
+  }
+  const v = parsed.data;
+
+  if (v.recipeId) {
+    const target = await db
+      .select({ kind: recipes.kind })
+      .from(recipes)
+      .where(eq(recipes.id, v.recipeId))
+      .limit(1);
+    if (!target[0]) {
+      return { success: false, error: "Recept neexistuje" };
+    }
+    if (target[0].kind !== "product") {
+      return {
+        success: false,
+        error: 'Iba recepty typu "produkt" je možné priradiť k produktu.',
+      };
+    }
+  }
+
+  try {
+    await db
+      .update(products)
+      .set({ recipeId: v.recipeId })
+      .where(eq(products.id, v.productId));
+    invalidate(v.recipeId ?? undefined, v.productId);
+    return { success: true };
+  } catch (err) {
+    log.recipes.error(
+      { err, productId: v.productId },
+      "Link product recipe failed"
+    );
+    return { success: false, error: "Prepojenie zlyhalo" };
+  }
+}
+
+function canAddSubRecipeMessage(reason: "self" | "cycle" | "depth"): string {
+  if (reason === "cycle") {
+    return "Subrecept by vytvoril cyklus.";
+  }
+  if (reason === "depth") {
+    return "Maximálna hĺbka subreceptov je 3.";
+  }
+  return "Subrecept nemôže odkazovať sám na seba.";
+}

--- a/src/features/recipes/api/queries.ts
+++ b/src/features/recipes/api/queries.ts
@@ -95,6 +95,7 @@ export async function getResolverContext(
         pricePerKgCents: ingredients.pricePerKgCents,
         pricePerPieceCents: ingredients.pricePerPieceCents,
         allergenCodes: ingredients.allergenCodes,
+        nutritionPer100: ingredients.nutritionPer100,
       })
       .from(ingredients),
     opts.includeDrafts
@@ -140,6 +141,7 @@ export async function getResolverContext(
       pricePerKgCents: i.pricePerKgCents,
       pricePerPieceCents: i.pricePerPieceCents,
       allergenCodes: i.allergenCodes as AllergenCode[],
+      nutritionPer100: i.nutritionPer100,
     });
   }
 

--- a/src/features/recipes/api/queries.ts
+++ b/src/features/recipes/api/queries.ts
@@ -1,0 +1,270 @@
+"use cache";
+
+import { and, asc, eq, isNotNull } from "drizzle-orm";
+import { cacheLife, cacheTag } from "next/cache";
+import { db } from "@/db";
+import { ingredients, products, recipeItems, recipes } from "@/db/schema";
+import type { AllergenCode } from "@/features/allergens/schema";
+import type {
+  IngredientLite,
+  RecipeLite,
+  ResolverContext,
+} from "../lib/cost-resolver";
+
+/**
+ * Recipe list. Defaults to sub-recipes (the standalone /admin/recipes
+ * page). Final-product recipes are reached through the product detail.
+ */
+export async function getRecipes(
+  opts: { kind?: "product" | "sub_recipe" } = {}
+) {
+  cacheLife("hours");
+  cacheTag("recipes");
+  if (opts.kind) {
+    return await db
+      .select()
+      .from(recipes)
+      .where(eq(recipes.kind, opts.kind))
+      .orderBy(asc(recipes.name));
+  }
+  return await db.select().from(recipes).orderBy(asc(recipes.name));
+}
+
+export type RecipeRow = Awaited<ReturnType<typeof getRecipes>>[number];
+
+/**
+ * Single recipe + ordered items with joined references. Used by the
+ * builder page and the product Recept tab.
+ */
+export async function getRecipeById(id: string) {
+  cacheLife("hours");
+  cacheTag("recipes", `recipe-${id}`);
+
+  const recipeRow = await db
+    .select()
+    .from(recipes)
+    .where(eq(recipes.id, id))
+    .limit(1);
+  if (!recipeRow[0]) {
+    return null;
+  }
+
+  const items = await db
+    .select({
+      id: recipeItems.id,
+      recipeId: recipeItems.recipeId,
+      ingredientId: recipeItems.ingredientId,
+      subRecipeId: recipeItems.subRecipeId,
+      quantityBaseUnit: recipeItems.quantityBaseUnit,
+      sortOrder: recipeItems.sortOrder,
+      notes: recipeItems.notes,
+    })
+    .from(recipeItems)
+    .where(eq(recipeItems.recipeId, id))
+    .orderBy(asc(recipeItems.sortOrder));
+
+  return { recipe: recipeRow[0], items };
+}
+
+export type RecipeWithItems = NonNullable<
+  Awaited<ReturnType<typeof getRecipeById>>
+>;
+
+/**
+ * Build the whole resolver context (ingredients + recipes as Maps).
+ * Used by the live preview (client side, cached page payload) and by
+ * the order snapshot at checkout (server side, cached query).
+ *
+ * `includeDrafts = true` for the admin builder (so previews work
+ * while building); `false` for the order snapshot path so customers
+ * only ever consume published recipes.
+ */
+export async function getResolverContext(
+  opts: { includeDrafts?: boolean } = {}
+): Promise<ResolverContext> {
+  cacheLife("hours");
+  cacheTag("recipes", "ingredients");
+
+  const [allIngredients, allRecipes, allItems] = await Promise.all([
+    db
+      .select({
+        id: ingredients.id,
+        name: ingredients.name,
+        baseUnit: ingredients.baseUnit,
+        gramsPerPiece: ingredients.gramsPerPiece,
+        pricePerKgCents: ingredients.pricePerKgCents,
+        pricePerPieceCents: ingredients.pricePerPieceCents,
+        allergenCodes: ingredients.allergenCodes,
+      })
+      .from(ingredients),
+    opts.includeDrafts
+      ? db
+          .select({
+            id: recipes.id,
+            name: recipes.name,
+            batchYieldUnits: recipes.batchYieldUnits,
+            batchYieldGrams: recipes.batchYieldGrams,
+            yieldLossPercent: recipes.yieldLossPercent,
+          })
+          .from(recipes)
+      : db
+          .select({
+            id: recipes.id,
+            name: recipes.name,
+            batchYieldUnits: recipes.batchYieldUnits,
+            batchYieldGrams: recipes.batchYieldGrams,
+            yieldLossPercent: recipes.yieldLossPercent,
+          })
+          .from(recipes)
+          .where(eq(recipes.status, "published")),
+    db
+      .select({
+        id: recipeItems.id,
+        recipeId: recipeItems.recipeId,
+        ingredientId: recipeItems.ingredientId,
+        subRecipeId: recipeItems.subRecipeId,
+        quantityBaseUnit: recipeItems.quantityBaseUnit,
+        sortOrder: recipeItems.sortOrder,
+      })
+      .from(recipeItems)
+      .orderBy(asc(recipeItems.sortOrder)),
+  ]);
+
+  const ingredientMap = new Map<string, IngredientLite>();
+  for (const i of allIngredients) {
+    ingredientMap.set(i.id, {
+      id: i.id,
+      name: i.name,
+      baseUnit: i.baseUnit,
+      gramsPerPiece: i.gramsPerPiece,
+      pricePerKgCents: i.pricePerKgCents,
+      pricePerPieceCents: i.pricePerPieceCents,
+      allergenCodes: i.allergenCodes as AllergenCode[],
+    });
+  }
+
+  const itemsByRecipe = new Map<string, typeof allItems>();
+  for (const item of allItems) {
+    const arr = itemsByRecipe.get(item.recipeId);
+    if (arr) {
+      arr.push(item);
+    } else {
+      itemsByRecipe.set(item.recipeId, [item]);
+    }
+  }
+
+  const recipeMap = new Map<string, RecipeLite>();
+  for (const r of allRecipes) {
+    recipeMap.set(r.id, {
+      id: r.id,
+      name: r.name,
+      batchYieldUnits: r.batchYieldUnits,
+      batchYieldGrams: r.batchYieldGrams,
+      yieldLossPercent: r.yieldLossPercent,
+      items: (itemsByRecipe.get(r.id) ?? []).map((it) => ({
+        id: it.id,
+        ingredientId: it.ingredientId,
+        subRecipeId: it.subRecipeId,
+        quantityBaseUnit: it.quantityBaseUnit,
+      })),
+    });
+  }
+
+  return { ingredients: ingredientMap, recipes: recipeMap };
+}
+
+/**
+ * Cheap adjacency map: recipeId -> sub-recipe IDs it references.
+ * Used by the picker's cycle/depth pre-check (`canAddSubRecipe`).
+ */
+export async function getRecipeGraph() {
+  cacheLife("hours");
+  cacheTag("recipes");
+
+  const rows = await db
+    .select({
+      parent: recipeItems.recipeId,
+      child: recipeItems.subRecipeId,
+    })
+    .from(recipeItems)
+    .where(isNotNull(recipeItems.subRecipeId));
+
+  const graph = new Map<string, string[]>();
+  for (const row of rows) {
+    if (!row.child) {
+      continue;
+    }
+    const arr = graph.get(row.parent);
+    if (arr) {
+      arr.push(row.child);
+    } else {
+      graph.set(row.parent, [row.child]);
+    }
+  }
+  return graph;
+}
+
+/**
+ * For a given recipe, return products that link to it (kind=product) AND
+ * other recipes that consume it as a sub-recipe. Used by the delete
+ * guard and the "used by N products" footer on sub-recipe pages.
+ */
+export async function getRecipeDependents(recipeId: string) {
+  cacheLife("hours");
+  cacheTag("recipes", `recipe-${recipeId}`);
+
+  const [linkedProducts, parentRecipes] = await Promise.all([
+    db
+      .select({ id: products.id, name: products.name, slug: products.slug })
+      .from(products)
+      .where(eq(products.recipeId, recipeId)),
+    db
+      .select({
+        id: recipes.id,
+        name: recipes.name,
+        slug: recipes.slug,
+      })
+      .from(recipeItems)
+      .innerJoin(recipes, eq(recipes.id, recipeItems.recipeId))
+      .where(eq(recipeItems.subRecipeId, recipeId)),
+  ]);
+  return { products: linkedProducts, parentRecipes };
+}
+
+/**
+ * "Najčastejšie" picker pin: top-N ingredients by recipe-item count.
+ * Cheap to compute, cached.
+ */
+export async function getMostUsedIngredients(limit = 10) {
+  cacheLife("hours");
+  cacheTag("recipes");
+
+  const rows = await db
+    .select({
+      id: ingredients.id,
+      name: ingredients.name,
+    })
+    .from(recipeItems)
+    .innerJoin(ingredients, eq(ingredients.id, recipeItems.ingredientId))
+    .where(
+      and(isNotNull(recipeItems.ingredientId), eq(ingredients.isActive, true))
+    )
+    .limit(limit);
+
+  // De-dupe by id while preserving order. Drizzle doesn't support
+  // GROUP BY ... ORDER BY count(*) DESC cleanly enough to be worth it
+  // at this scale; a Map de-dupe is fine for <500 active ingredients.
+  const seen = new Set<string>();
+  const out: Array<{ id: string; name: string }> = [];
+  for (const r of rows) {
+    if (seen.has(r.id)) {
+      continue;
+    }
+    seen.add(r.id);
+    out.push(r);
+    if (out.length >= limit) {
+      break;
+    }
+  }
+  return out;
+}

--- a/src/features/recipes/components/ingredient-picker.tsx
+++ b/src/features/recipes/components/ingredient-picker.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { PlusIcon } from "lucide-react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { type CanAddResult, canAddSubRecipe } from "../lib/cost-resolver";
+
+interface IngredientOption {
+  baseUnit: "g" | "piece";
+  id: string;
+  name: string;
+}
+
+interface SubRecipeOption {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  /** This recipe's id; used to filter self + cycle candidates. */
+  hostRecipeId: string;
+  ingredients: IngredientOption[];
+  mostUsedIds?: string[];
+  onPickIngredient: (ingredientId: string) => void;
+  onPickSubRecipe: (subRecipeId: string) => void;
+  /** Pinned at top of the list. */
+  recentIds?: string[];
+  /** Adjacency map for cycle/depth check on sub-recipes. */
+  recipesGraph: ReadonlyMap<string, readonly string[]>;
+  subRecipes: SubRecipeOption[];
+  /** Set of ingredient/sub-recipe IDs already in the current recipe. */
+  usedIds: Set<string>;
+}
+
+/**
+ * Single-add `<Command>` palette. Lists ingredients + sub-recipes; the
+ * dual-mode "Z iného receptu" tab is deferred to a follow-up (admin can
+ * use the recipe Duplikovať flow for now).
+ */
+export function IngredientPicker({
+  ingredients,
+  subRecipes,
+  usedIds,
+  recipesGraph,
+  hostRecipeId,
+  recentIds = [],
+  mostUsedIds = [],
+  onPickIngredient,
+  onPickSubRecipe,
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  const filteredIngredients = useMemo(
+    () => ingredients.filter((i) => !usedIds.has(i.id)),
+    [ingredients, usedIds]
+  );
+
+  const filteredSubRecipes = useMemo(() => {
+    return subRecipes
+      .filter((r) => !usedIds.has(r.id))
+      .map((r) => ({
+        ...r,
+        check: canAddSubRecipe(hostRecipeId, r.id, recipesGraph),
+      }))
+      .filter(
+        (r): r is SubRecipeOption & { check: CanAddResult } => r.check.ok
+      );
+  }, [subRecipes, usedIds, recipesGraph, hostRecipeId]);
+
+  const pinnedRecent = recentIds
+    .map((id) => filteredIngredients.find((i) => i.id === id))
+    .filter((x): x is IngredientOption => Boolean(x));
+  const pinnedFrequent = mostUsedIds
+    .filter((id) => !recentIds.includes(id))
+    .map((id) => filteredIngredients.find((i) => i.id === id))
+    .filter((x): x is IngredientOption => Boolean(x));
+
+  const handlePickIngredient = (id: string) => {
+    onPickIngredient(id);
+    setOpen(false);
+  };
+  const handlePickSubRecipe = (id: string) => {
+    onPickSubRecipe(id);
+    setOpen(false);
+  };
+
+  return (
+    <Dialog onOpenChange={setOpen} open={open}>
+      <DialogTrigger asChild>
+        <button
+          className="flex items-center gap-2 rounded-md border border-dashed px-3 py-2 text-sm hover:bg-accent"
+          type="button"
+        >
+          <PlusIcon className="size-4" />
+          Pridať ingredienciu / subrecept
+        </button>
+      </DialogTrigger>
+      <DialogContent className="max-w-xl overflow-hidden p-0">
+        <DialogHeader className="border-b px-4 py-3">
+          <DialogTitle className="text-base">Vybrať položku</DialogTitle>
+          <DialogDescription className="text-xs">
+            Začnite písať pre fuzzy vyhľadávanie. „muka" nájde „Hladká múka
+            T650".
+          </DialogDescription>
+        </DialogHeader>
+        <Command>
+          <CommandInput placeholder="Hľadať..." />
+          <CommandList>
+            <CommandEmpty>Nič sa nenašlo</CommandEmpty>
+
+            {pinnedRecent.length > 0 && (
+              <CommandGroup heading="Naposledy použité">
+                {pinnedRecent.map((i) => (
+                  <CommandItem
+                    key={`r-${i.id}`}
+                    onSelect={() => handlePickIngredient(i.id)}
+                    value={i.name}
+                  >
+                    {i.name}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            {pinnedFrequent.length > 0 && (
+              <CommandGroup heading="Najčastejšie">
+                {pinnedFrequent.map((i) => (
+                  <CommandItem
+                    key={`f-${i.id}`}
+                    onSelect={() => handlePickIngredient(i.id)}
+                    value={i.name}
+                  >
+                    {i.name}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            <CommandGroup heading="Ingrediencie">
+              {filteredIngredients.map((i) => (
+                <CommandItem
+                  key={i.id}
+                  onSelect={() => handlePickIngredient(i.id)}
+                  value={i.name}
+                >
+                  <span className="flex-1">{i.name}</span>
+                  <span className="text-muted-foreground text-xs">
+                    {i.baseUnit === "g" ? "g" : "ks"}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+
+            {filteredSubRecipes.length > 0 && (
+              <CommandGroup heading="Subrecepty">
+                {filteredSubRecipes.map((r) => (
+                  <CommandItem
+                    key={r.id}
+                    onSelect={() => handlePickSubRecipe(r.id)}
+                    value={`subrecept ${r.name}`}
+                  >
+                    <span className="mr-2">📦</span>
+                    <span className="flex-1">{r.name}</span>
+                    <span className="text-muted-foreground text-xs">g</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            <CommandGroup heading="Iné">
+              <CommandItem asChild>
+                <Link
+                  className="cursor-pointer"
+                  href={"/admin/ingredients" as never}
+                  target="_blank"
+                >
+                  + Vytvoriť novú surovinu (nová karta)
+                </Link>
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/recipes/components/live-preview-panel.tsx
+++ b/src/features/recipes/components/live-preview-panel.tsx
@@ -1,0 +1,99 @@
+import { CircleAlertIcon, XCircleIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { Allergen } from "@/features/allergens/api/queries";
+import { AllergenChipStrip } from "@/features/allergens/components/allergen-picker";
+import type { AllergenCode } from "@/features/allergens/schema";
+import { formatCentsAsEur } from "@/features/ingredients/lib/price-conversion";
+import type { ClientPreview } from "../lib/client-preview";
+
+interface Props {
+  allergens: Allergen[];
+  preview: ClientPreview;
+}
+
+/**
+ * Sticky right-side panel on the recipe builder. Shows cost per unit,
+ * batch cost + yield, derived allergens, and warnings about zero-priced
+ * items or missing batch yield grams.
+ *
+ * Nutrition section is added in Phase D.
+ */
+export function LivePreviewPanel({ preview, allergens }: Props) {
+  if (!preview.ok) {
+    return (
+      <aside className="space-y-3 rounded-lg border bg-card p-4">
+        <h3 className="font-semibold text-sm">Živý náhľad</h3>
+        <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-destructive text-sm">
+          <XCircleIcon className="mt-0.5 size-4 shrink-0" />
+          <p>{preview.error}</p>
+        </div>
+      </aside>
+    );
+  }
+
+  const r = preview.resolved;
+  const withoutPrice = r.trace.filter((t) => !t.hasPrice);
+  const noBatchMass = r.finishedMassGrams === 0;
+
+  return (
+    <aside className="space-y-4 rounded-lg border bg-card p-4">
+      <h3 className="font-semibold text-sm">Živý náhľad</h3>
+
+      <div>
+        <p className="text-muted-foreground text-xs">Cena za kus</p>
+        <p className="font-semibold text-2xl tabular-nums">
+          {formatCentsAsEur(r.costPerUnitCents)}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 text-sm">
+        <div>
+          <p className="text-muted-foreground text-xs">Šarža</p>
+          <p className="font-medium tabular-nums">
+            {formatCentsAsEur(r.batchCostCents)}
+          </p>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs">Výnos (čistý)</p>
+          <p className="font-medium tabular-nums">{r.finishedMassGrams} g</p>
+        </div>
+      </div>
+
+      <div>
+        <p className="mb-1.5 text-muted-foreground text-xs">Alergény</p>
+        {r.allergenCodes.length > 0 ? (
+          <AllergenChipStrip
+            allergens={allergens}
+            codes={r.allergenCodes as AllergenCode[]}
+          />
+        ) : (
+          <p className="text-muted-foreground text-sm">—</p>
+        )}
+      </div>
+
+      {(withoutPrice.length > 0 || noBatchMass) && (
+        <div className="space-y-1 rounded-md border border-amber-300 bg-amber-50 p-2 text-amber-800 text-xs dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
+          {withoutPrice.length > 0 && (
+            <div className="flex items-start gap-1.5">
+              <CircleAlertIcon className="mt-0.5 size-3 shrink-0" />
+              <span>
+                {withoutPrice.length} surovín bez ceny — vypočítaná cena je
+                neúplná.
+              </span>
+            </div>
+          )}
+          {noBatchMass && (
+            <div className="flex items-start gap-1.5">
+              <CircleAlertIcon className="mt-0.5 size-3 shrink-0" />
+              <span>Šarža nemá zadanú hmotnosť (g).</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      <Badge className="text-[10px]" variant="secondary">
+        Phase D doplní nutričné hodnoty
+      </Badge>
+    </aside>
+  );
+}

--- a/src/features/recipes/components/product-recipe-card.tsx
+++ b/src/features/recipes/components/product-recipe-card.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { ExternalLinkIcon, UnlinkIcon } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { formatCentsAsEur } from "@/features/ingredients/lib/price-conversion";
+import { createRecipeAction, linkProductRecipeAction } from "../api/actions";
+
+interface LinkedRecipeSummary {
+  costPerUnitCents: number | null;
+  id: string;
+  name: string;
+  /** When the resolver throws, surface a Slovak error message. */
+  resolverError: string | null;
+  status: "draft" | "published";
+}
+
+interface UnlinkedRecipeOption {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  availableProductRecipes: UnlinkedRecipeOption[];
+  linkedRecipe: LinkedRecipeSummary | null;
+  productId: string;
+}
+
+/**
+ * Compact "Recept" card on the product detail page. Three states:
+ * - No recipe → Vytvoriť / Prepojiť existujúci
+ * - Linked → name, summary, Otvoriť ↗, Odpojiť
+ * - Orphaned recipe with resolver error → warning + Odpojiť
+ *
+ * Full Recept tab integration with a tab strip is a follow-up; this
+ * card lives inline alongside the existing form.
+ */
+export function ProductRecipeCard({
+  productId,
+  linkedRecipe,
+  availableProductRecipes,
+}: Props) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [selectedExistingId, setSelectedExistingId] = useState<string | null>(
+    null
+  );
+
+  const handleCreate = () => {
+    startTransition(async () => {
+      // createRecipeAction throws a redirect sentinel on success — let it bubble.
+      await createRecipeAction({ kind: "product", productId });
+    });
+  };
+
+  const handleLinkExisting = () => {
+    if (!selectedExistingId) {
+      toast.error("Vyberte recept");
+      return;
+    }
+    const id = selectedExistingId;
+    startTransition(async () => {
+      const res = await linkProductRecipeAction({
+        productId,
+        recipeId: id,
+      });
+      if (res.success) {
+        toast.success("Recept priradený");
+        router.refresh();
+      } else {
+        toast.error(res.error);
+      }
+    });
+  };
+
+  const handleUnlink = () => {
+    startTransition(async () => {
+      const res = await linkProductRecipeAction({
+        productId,
+        recipeId: null,
+      });
+      if (res.success) {
+        toast.success("Recept odpojený");
+        router.refresh();
+      } else {
+        toast.error(res.error);
+      }
+    });
+  };
+
+  if (!linkedRecipe) {
+    return (
+      <aside className="space-y-3 rounded-lg border bg-card p-4">
+        <div>
+          <h3 className="font-semibold text-sm">Recept</h3>
+          <p className="text-muted-foreground text-xs">
+            Pripojte recept aby sa vypočítala produkčná cena a (Phase D) sa
+            odvodili nutričné hodnoty.
+          </p>
+        </div>
+        <div className="flex flex-col gap-2">
+          <Button disabled={pending} onClick={handleCreate} size="sm">
+            {pending && <Spinner />}
+            Vytvoriť recept
+          </Button>
+          {availableProductRecipes.length > 0 && (
+            <div className="flex flex-col gap-2">
+              <p className="text-muted-foreground text-xs">
+                Alebo prepojiť existujúci:
+              </p>
+              <div className="flex items-center gap-2">
+                <Select
+                  onValueChange={setSelectedExistingId}
+                  value={selectedExistingId ?? undefined}
+                >
+                  <SelectTrigger className="flex-1">
+                    <SelectValue placeholder="Vybrať recept..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableProductRecipes.map((r) => (
+                      <SelectItem key={r.id} value={r.id}>
+                        {r.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Button
+                  disabled={pending || !selectedExistingId}
+                  onClick={handleLinkExisting}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  Prepojiť
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="space-y-3 rounded-lg border bg-card p-4">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="font-semibold text-sm">Recept</h3>
+        <span className="text-muted-foreground text-xs">
+          {linkedRecipe.status === "published" ? "Publikovaný" : "Koncept"}
+        </span>
+      </div>
+
+      <Link
+        className="block font-medium hover:underline"
+        href={`/admin/recipes/${linkedRecipe.id}` as never}
+      >
+        {linkedRecipe.name}
+      </Link>
+
+      {linkedRecipe.resolverError ? (
+        <p className="rounded-md border border-destructive/50 bg-destructive/10 p-2 text-destructive text-xs">
+          {linkedRecipe.resolverError}
+        </p>
+      ) : (
+        <div>
+          <p className="text-muted-foreground text-xs">Cena za kus</p>
+          <p className="font-semibold text-xl tabular-nums">
+            {linkedRecipe.costPerUnitCents === null
+              ? "—"
+              : formatCentsAsEur(linkedRecipe.costPerUnitCents)}
+          </p>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <Button asChild size="sm" variant="outline">
+          <Link href={`/admin/recipes/${linkedRecipe.id}` as never}>
+            <ExternalLinkIcon className="mr-1 size-3.5" />
+            Otvoriť
+          </Link>
+        </Button>
+        <Button
+          disabled={pending}
+          onClick={handleUnlink}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          <UnlinkIcon className="mr-1 size-3.5" />
+          Odpojiť
+        </Button>
+      </div>
+    </aside>
+  );
+}

--- a/src/features/recipes/components/recipe-builder.tsx
+++ b/src/features/recipes/components/recipe-builder.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
+import type { Allergen } from "@/features/allergens/api/queries";
+import { addRecipeItemAction } from "../api/actions";
+import {
+  type ClientPreview,
+  computeClientPreview,
+} from "../lib/client-preview";
+import type {
+  IngredientLite,
+  RecipeItemLite,
+  RecipeLite,
+} from "../lib/cost-resolver";
+import type { RecipeHeaderSchema } from "../schema";
+import { IngredientPicker } from "./ingredient-picker";
+import { LivePreviewPanel } from "./live-preview-panel";
+import { RecipeHeaderForm } from "./recipe-header-form";
+import { RecipeItemsTable } from "./recipe-items-table";
+
+interface BuilderItem {
+  id: string;
+  ingredientId: string | null;
+  quantityBaseUnit: number;
+  sortOrder: number;
+  subRecipeId: string | null;
+}
+
+interface Props {
+  /** All allergens (sk names + icons). */
+  allergens: Allergen[];
+  /** Catalog snapshot loaded server-side; passed in to feed the resolver. */
+  ingredientsMap: Map<string, IngredientLite>;
+  initialHeader: RecipeHeaderSchema;
+  initialItems: BuilderItem[];
+  /** Picker pin sources. */
+  mostUsedIds: string[];
+  /** Active ingredient catalog for the picker. */
+  pickerIngredients: Array<{
+    id: string;
+    name: string;
+    baseUnit: "g" | "piece";
+  }>;
+  pickerSubRecipes: Array<{ id: string; name: string }>;
+  recipeId: string;
+  recipesGraph: Map<string, string[]>;
+  recipesMap: Map<string, RecipeLite>;
+}
+
+const RECENT_KEY = "recipe-builder:recent";
+const RECENT_MAX = 10;
+
+function readRecent(): string[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(RECENT_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((x): x is string => typeof x === "string");
+  } catch {
+    return [];
+  }
+}
+
+function pushRecent(id: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  const current = readRecent();
+  const next = [id, ...current.filter((x) => x !== id)].slice(0, RECENT_MAX);
+  try {
+    window.localStorage.setItem(RECENT_KEY, JSON.stringify(next));
+  } catch {
+    // ignore quota errors
+  }
+}
+
+export function RecipeBuilder({
+  recipeId,
+  initialHeader,
+  initialItems,
+  ingredientsMap,
+  recipesMap,
+  recipesGraph,
+  mostUsedIds,
+  allergens,
+  pickerIngredients,
+  pickerSubRecipes,
+}: Props) {
+  const [header, setHeader] = useState<RecipeHeaderSchema>(initialHeader);
+  const [items, setItems] = useState<BuilderItem[]>(initialItems);
+  const [pendingAdd, startAddTransition] = useTransition();
+
+  const usedIds = useMemo(() => {
+    const s = new Set<string>();
+    for (const it of items) {
+      if (it.ingredientId) {
+        s.add(it.ingredientId);
+      }
+      if (it.subRecipeId) {
+        s.add(it.subRecipeId);
+      }
+    }
+    return s;
+  }, [items]);
+
+  const recentIds = useMemo(() => readRecent(), []);
+
+  const preview: ClientPreview = useMemo(() => {
+    const resolverItems: RecipeItemLite[] = items.map((it) => ({
+      id: it.id,
+      ingredientId: it.ingredientId,
+      subRecipeId: it.subRecipeId,
+      quantityBaseUnit: it.quantityBaseUnit,
+    }));
+    return computeClientPreview({
+      recipeId,
+      recipe: {
+        batchYieldUnits: header.batchYieldUnits,
+        batchYieldGrams: header.batchYieldGrams,
+        yieldLossPercent: header.yieldLossPercent,
+      },
+      items: resolverItems,
+      ctx: { ingredients: ingredientsMap, recipes: recipesMap },
+    });
+  }, [items, header, recipeId, ingredientsMap, recipesMap]);
+
+  const displayRows = useMemo(() => {
+    if (!preview.ok) {
+      return [];
+    }
+    const totalBatch = preview.resolved.batchCostCents;
+    return preview.resolved.trace.map((t) => {
+      const unit: "g" | "piece" =
+        t.kind === "sub_recipe"
+          ? "g"
+          : (ingredientsMap.get(t.refId)?.baseUnit ?? "g");
+      return {
+        id: t.itemId ?? "",
+        refId: t.refId,
+        kind: t.kind,
+        refName:
+          t.kind === "ingredient"
+            ? (ingredientsMap.get(t.refId)?.name ?? t.refId)
+            : (recipesMap.get(t.refId)?.name ?? t.refId),
+        quantityBaseUnit: t.quantityBaseUnit,
+        unit,
+        totalCostCents: t.totalCostCents,
+        pctOfBatch: totalBatch > 0 ? (t.totalCostCents / totalBatch) * 100 : 0,
+        hasPrice: t.hasPrice,
+      };
+    });
+  }, [preview, ingredientsMap, recipesMap]);
+
+  const handlePickIngredient = (ingredientId: string) => {
+    pushRecent(ingredientId);
+    startAddTransition(async () => {
+      const res = await addRecipeItemAction({
+        recipeId,
+        ingredientId,
+        subRecipeId: null,
+        quantityBaseUnit: 100,
+      });
+      if (res.success) {
+        setItems((prev) => [
+          ...prev,
+          {
+            id: res.itemId,
+            ingredientId,
+            subRecipeId: null,
+            quantityBaseUnit: 100,
+            sortOrder: prev.length,
+          },
+        ]);
+        toast.success("Pridané");
+      } else {
+        toast.error(res.error);
+      }
+    });
+  };
+
+  const handlePickSubRecipe = (subRecipeId: string) => {
+    startAddTransition(async () => {
+      const res = await addRecipeItemAction({
+        recipeId,
+        ingredientId: null,
+        subRecipeId,
+        quantityBaseUnit: 100,
+      });
+      if (res.success) {
+        setItems((prev) => [
+          ...prev,
+          {
+            id: res.itemId,
+            ingredientId: null,
+            subRecipeId,
+            quantityBaseUnit: 100,
+            sortOrder: prev.length,
+          },
+        ]);
+        toast.success("Pridané");
+      } else {
+        toast.error(res.error);
+      }
+    });
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
+      <div className="space-y-6">
+        <RecipeHeaderForm
+          initial={initialHeader}
+          onChange={setHeader}
+          recipeId={recipeId}
+        />
+
+        <section>
+          <h2 className="mb-2 font-semibold text-sm">Položky</h2>
+          <RecipeItemsTable
+            onLocalRemove={(id) =>
+              setItems((prev) => prev.filter((p) => p.id !== id))
+            }
+            onLocalReorder={(orderedIds) =>
+              setItems((prev) => {
+                const map = new Map(prev.map((p) => [p.id, p] as const));
+                return orderedIds
+                  .map((id, idx) => {
+                    const found = map.get(id);
+                    return found ? { ...found, sortOrder: idx } : null;
+                  })
+                  .filter((x): x is BuilderItem => Boolean(x));
+              })
+            }
+            onLocalUpdate={(id, qty) =>
+              setItems((prev) =>
+                prev.map((p) =>
+                  p.id === id ? { ...p, quantityBaseUnit: qty } : p
+                )
+              )
+            }
+            recipeId={recipeId}
+            rows={displayRows}
+          />
+          <div className="mt-3 flex items-center gap-2">
+            <IngredientPicker
+              hostRecipeId={recipeId}
+              ingredients={pickerIngredients}
+              mostUsedIds={mostUsedIds}
+              onPickIngredient={handlePickIngredient}
+              onPickSubRecipe={handlePickSubRecipe}
+              recentIds={recentIds}
+              recipesGraph={recipesGraph}
+              subRecipes={pickerSubRecipes}
+              usedIds={usedIds}
+            />
+            {pendingAdd && (
+              <span className="text-muted-foreground text-xs">Pridávam...</span>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <div className="lg:sticky lg:top-4 lg:self-start">
+        <LivePreviewPanel allergens={allergens} preview={preview} />
+      </div>
+    </div>
+  );
+}

--- a/src/features/recipes/components/recipe-header-form.tsx
+++ b/src/features/recipes/components/recipe-header-form.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { CheckIcon } from "lucide-react";
+import { useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldSet,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import { Textarea } from "@/components/ui/textarea";
+import { publishRecipeAction, updateRecipeHeaderAction } from "../api/actions";
+import type { RecipeHeaderSchema } from "../schema";
+
+interface Props {
+  initial: RecipeHeaderSchema;
+  /** Called when the admin edits header values; parent uses for live preview. */
+  onChange: (next: RecipeHeaderSchema) => void;
+  recipeId: string;
+}
+
+export function RecipeHeaderForm({ recipeId, initial, onChange }: Props) {
+  const [state, setState] = useState<RecipeHeaderSchema>(initial);
+  const [saving, startSave] = useTransition();
+  const [publishing, startPublish] = useTransition();
+
+  const update = <K extends keyof RecipeHeaderSchema>(
+    key: K,
+    value: RecipeHeaderSchema[K]
+  ) => {
+    setState((prev) => {
+      const next = { ...prev, [key]: value };
+      onChange(next);
+      return next;
+    });
+  };
+
+  const handleSave = () => {
+    startSave(async () => {
+      const res = await updateRecipeHeaderAction({ id: recipeId, data: state });
+      if (res.success) {
+        toast.success("Recept uložený");
+      } else {
+        toast.error(res.error);
+      }
+    });
+  };
+
+  const handlePublish = () => {
+    startPublish(async () => {
+      const res = await publishRecipeAction({ id: recipeId });
+      if (res.success) {
+        toast.success("Recept publikovaný");
+        setState((prev) => ({ ...prev, status: "published" }));
+      } else {
+        toast.error(res.error);
+      }
+    });
+  };
+
+  return (
+    <FieldSet className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <FieldLabel>Recept</FieldLabel>
+        <div className="flex items-center gap-2">
+          {state.status === "draft" && (
+            <Button
+              disabled={publishing}
+              onClick={handlePublish}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              {publishing ? <Spinner /> : <CheckIcon className="mr-1 size-4" />}
+              Publikovať
+            </Button>
+          )}
+          <Button
+            disabled={saving}
+            onClick={handleSave}
+            size="sm"
+            type="button"
+          >
+            {saving && <Spinner />}
+            Uložiť
+          </Button>
+        </div>
+      </div>
+
+      <FieldGroup className="grid gap-4 md:grid-cols-2">
+        <Field>
+          <FieldContent>
+            <FieldLabel htmlFor="rec-name">Názov</FieldLabel>
+          </FieldContent>
+          <Input
+            id="rec-name"
+            onChange={(e) => update("name", e.target.value)}
+            value={state.name}
+          />
+        </Field>
+
+        <Field>
+          <FieldContent>
+            <FieldLabel htmlFor="rec-slug">Slug</FieldLabel>
+          </FieldContent>
+          <Input
+            id="rec-slug"
+            onChange={(e) => update("slug", e.target.value)}
+            value={state.slug}
+          />
+        </Field>
+
+        <Field>
+          <FieldContent>
+            <FieldLabel>Typ</FieldLabel>
+            <FieldDescription>
+              „Produkt" je finálny recept; „Subrecept" sa znova používa v iných
+              receptoch (kvások, krém...).
+            </FieldDescription>
+          </FieldContent>
+          <Select
+            onValueChange={(v) => update("kind", v as "product" | "sub_recipe")}
+            value={state.kind}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="product">Produkt (finálny)</SelectItem>
+              <SelectItem value="sub_recipe">Subrecept</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+
+        <Field>
+          <FieldContent>
+            <FieldLabel>Stav</FieldLabel>
+          </FieldContent>
+          <Select
+            onValueChange={(v) => update("status", v as "draft" | "published")}
+            value={state.status}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="draft">Koncept</SelectItem>
+              <SelectItem value="published">Publikovaný</SelectItem>
+            </SelectContent>
+          </Select>
+        </Field>
+
+        <Field>
+          <FieldContent>
+            <FieldLabel htmlFor="rec-yield-units">Výnos (ks)</FieldLabel>
+            <FieldDescription>
+              Koľko kusov produkuje jedna šarža.
+            </FieldDescription>
+          </FieldContent>
+          <Input
+            id="rec-yield-units"
+            inputMode="numeric"
+            onChange={(e) =>
+              update(
+                "batchYieldUnits",
+                Number.parseInt(e.target.value, 10) || 1
+              )
+            }
+            type="number"
+            value={state.batchYieldUnits}
+          />
+        </Field>
+
+        <Field>
+          <FieldContent>
+            <FieldLabel htmlFor="rec-yield-grams">
+              Hmotnosť šarže (g)
+            </FieldLabel>
+            <FieldDescription>
+              Súčet hmotnosti pred pečením; použité pre nutričné hodnoty.
+            </FieldDescription>
+          </FieldContent>
+          <Input
+            id="rec-yield-grams"
+            inputMode="numeric"
+            onChange={(e) =>
+              update(
+                "batchYieldGrams",
+                Number.parseInt(e.target.value, 10) || 0
+              )
+            }
+            type="number"
+            value={state.batchYieldGrams}
+          />
+        </Field>
+
+        <Field>
+          <FieldContent>
+            <FieldLabel htmlFor="rec-loss">Strata (%)</FieldLabel>
+            <FieldDescription>
+              Strata hmotnosti pri pečení (typicky 10-12 %).
+            </FieldDescription>
+          </FieldContent>
+          <Input
+            id="rec-loss"
+            inputMode="numeric"
+            max={50}
+            min={0}
+            onChange={(e) =>
+              update(
+                "yieldLossPercent",
+                Math.max(
+                  0,
+                  Math.min(50, Number.parseInt(e.target.value, 10) || 0)
+                )
+              )
+            }
+            type="number"
+            value={state.yieldLossPercent}
+          />
+        </Field>
+
+        <Field className="md:col-span-2">
+          <FieldContent>
+            <FieldLabel htmlFor="rec-notes">Poznámky</FieldLabel>
+          </FieldContent>
+          <Textarea
+            id="rec-notes"
+            onChange={(e) => update("notes", e.target.value || null)}
+            rows={2}
+            value={state.notes ?? ""}
+          />
+        </Field>
+      </FieldGroup>
+    </FieldSet>
+  );
+}

--- a/src/features/recipes/components/recipe-items-table.tsx
+++ b/src/features/recipes/components/recipe-items-table.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import {
+  ArrowDownIcon,
+  ArrowUpIcon,
+  CircleAlertIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { formatCentsAsEur } from "@/features/ingredients/lib/price-conversion";
+import { cn } from "@/lib/utils";
+import {
+  removeRecipeItemAction,
+  reorderRecipeItemsAction,
+  updateRecipeItemAction,
+} from "../api/actions";
+
+interface ItemDisplayRow {
+  hasPrice: boolean;
+  id: string;
+  kind: "ingredient" | "sub_recipe";
+  pctOfBatch: number;
+  quantityBaseUnit: number;
+  refId: string;
+  refName: string;
+  totalCostCents: number;
+  unit: "g" | "piece";
+}
+
+interface Props {
+  /** Called when admin removes a row locally (optimistic UI). */
+  onLocalRemove: (itemId: string) => void;
+  /** Called after a successful server reorder; parent refreshes. */
+  onLocalReorder: (orderedIds: string[]) => void;
+  /** Called when admin edits a quantity locally (before server save). */
+  onLocalUpdate: (itemId: string, qty: number) => void;
+  recipeId: string;
+  rows: ItemDisplayRow[];
+}
+
+/**
+ * Items table for the recipe builder. Quantity input is debounced and
+ * server-saved on blur. Reorder uses up/down arrows (dnd-kit deferred
+ * to a follow-up to keep this PR scoped).
+ */
+export function RecipeItemsTable({
+  recipeId,
+  rows,
+  onLocalUpdate,
+  onLocalRemove,
+  onLocalReorder,
+}: Props) {
+  const [pending, startTransition] = useTransition();
+
+  const handleQtyBlur = (itemId: string, raw: string) => {
+    const qty = Number.parseInt(raw, 10);
+    if (!Number.isFinite(qty) || qty <= 0) {
+      toast.error("Množstvo musí byť kladné číslo");
+      return;
+    }
+    startTransition(async () => {
+      const res = await updateRecipeItemAction({
+        itemId,
+        quantityBaseUnit: qty,
+      });
+      if (!res.success) {
+        toast.error(res.error);
+      }
+    });
+  };
+
+  const handleRemove = (itemId: string) => {
+    onLocalRemove(itemId);
+    startTransition(async () => {
+      const res = await removeRecipeItemAction({ itemId });
+      if (!res.success) {
+        toast.error(res.error);
+      }
+    });
+  };
+
+  const handleMove = (idx: number, direction: -1 | 1) => {
+    const target = idx + direction;
+    if (target < 0 || target >= rows.length) {
+      return;
+    }
+    const newOrder = rows.slice();
+    const [moved] = newOrder.splice(idx, 1);
+    newOrder.splice(target, 0, moved);
+    const orderedIds = newOrder.map((r) => r.id);
+    onLocalReorder(orderedIds);
+    startTransition(async () => {
+      const res = await reorderRecipeItemsAction({
+        recipeId,
+        orderedItemIds: orderedIds,
+      });
+      if (!res.success) {
+        toast.error(res.error);
+      }
+    });
+  };
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-md border border-dashed p-8 text-center text-muted-foreground text-sm">
+        Recept nemá žiadne položky. Pridajte prvú ingredienciu nižšie.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-md border">
+      <table className="w-full text-sm">
+        <thead className="border-b bg-muted/40 text-left text-muted-foreground text-xs">
+          <tr>
+            <th className="w-8" />
+            <th className="px-3 py-2 font-medium">Položka</th>
+            <th className="px-3 py-2 font-medium">Množstvo</th>
+            <th className="px-3 py-2 font-medium">Cena</th>
+            <th className="px-3 py-2 font-medium">% šarže</th>
+            <th className="w-10" />
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, idx) => (
+            <tr
+              className={cn(
+                "border-b",
+                !row.hasPrice && "bg-amber-50/40 dark:bg-amber-950/20"
+              )}
+              key={row.id}
+            >
+              <td className="px-2 py-1">
+                <div className="flex flex-col">
+                  <button
+                    aria-label="Posunúť hore"
+                    className="text-muted-foreground hover:text-foreground disabled:opacity-30"
+                    disabled={idx === 0 || pending}
+                    onClick={() => handleMove(idx, -1)}
+                    type="button"
+                  >
+                    <ArrowUpIcon className="size-3" />
+                  </button>
+                  <button
+                    aria-label="Posunúť dolu"
+                    className="text-muted-foreground hover:text-foreground disabled:opacity-30"
+                    disabled={idx === rows.length - 1 || pending}
+                    onClick={() => handleMove(idx, 1)}
+                    type="button"
+                  >
+                    <ArrowDownIcon className="size-3" />
+                  </button>
+                </div>
+              </td>
+              <td className="px-3 py-2">
+                <span className="font-medium">
+                  {row.kind === "sub_recipe" && (
+                    <span className="mr-1">📦</span>
+                  )}
+                  {row.refName}
+                </span>
+                {!row.hasPrice && (
+                  <span className="ml-2 inline-flex items-center gap-0.5 text-amber-700 text-xs dark:text-amber-400">
+                    <CircleAlertIcon className="size-3" />
+                    bez ceny
+                  </span>
+                )}
+              </td>
+              <td className="px-3 py-2">
+                <div className="flex items-center gap-1">
+                  <Input
+                    className="w-20"
+                    defaultValue={row.quantityBaseUnit}
+                    inputMode="numeric"
+                    onBlur={(e) => handleQtyBlur(row.id, e.target.value)}
+                    onChange={(e) => {
+                      const n = Number.parseInt(e.target.value, 10);
+                      if (Number.isFinite(n) && n > 0) {
+                        onLocalUpdate(row.id, n);
+                      }
+                    }}
+                    type="number"
+                  />
+                  <span className="text-muted-foreground text-xs">
+                    {row.unit === "g" ? "g" : "ks"}
+                  </span>
+                </div>
+              </td>
+              <td className="px-3 py-2 font-mono text-xs">
+                {row.hasPrice ? formatCentsAsEur(row.totalCostCents) : "—"}
+              </td>
+              <td className="px-3 py-2 text-muted-foreground text-xs">
+                {row.pctOfBatch.toFixed(0)} %
+              </td>
+              <td className="px-2 py-1 text-right">
+                <Button
+                  aria-label="Odstrániť položku"
+                  disabled={pending}
+                  onClick={() => handleRemove(row.id)}
+                  size="icon"
+                  type="button"
+                  variant="ghost"
+                >
+                  {pending ? <Spinner /> : <Trash2Icon className="size-4" />}
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/recipes/lib/client-preview.ts
+++ b/src/features/recipes/lib/client-preview.ts
@@ -1,0 +1,96 @@
+/**
+ * Client-side wrapper around the cost resolver. The recipe builder page
+ * loads the full resolver context server-side once, then the live
+ * preview panel recomputes locally on every keystroke for instant
+ * feedback. Server-authoritative compute on save reconciles.
+ */
+import type { AllergenCode } from "@/features/allergens/schema";
+import {
+  type IngredientLite,
+  type RecipeItemLite,
+  type RecipeLite,
+  type ResolvedRecipe,
+  type ResolverContext,
+  resolveRecipeCost,
+} from "./cost-resolver";
+
+export interface ClientPreviewInput {
+  /** Pass through the page-loaded ingredient/recipe catalog. */
+  ctx: {
+    ingredients: ReadonlyMap<string, IngredientLite>;
+    recipes: ReadonlyMap<string, RecipeLite>;
+  };
+  items: RecipeItemLite[];
+  recipe: {
+    batchYieldUnits: number;
+    batchYieldGrams: number;
+    yieldLossPercent: number;
+  };
+  recipeId: string;
+}
+
+export type ClientPreview =
+  | { ok: true; resolved: ResolvedRecipe }
+  | { ok: false; error: string; code: "cycle" | "depth" | "missing" | "other" };
+
+/**
+ * Build an ephemeral ResolverContext where the current (in-flight)
+ * recipe overrides whatever's in the cached catalog, then resolve.
+ * Maps any resolver error to a user-facing Slovak message.
+ */
+export function computeClientPreview(input: ClientPreviewInput): ClientPreview {
+  const recipes = new Map(input.ctx.recipes);
+  const liveRecipe: RecipeLite = {
+    id: input.recipeId,
+    name: "",
+    batchYieldUnits: input.recipe.batchYieldUnits,
+    batchYieldGrams: input.recipe.batchYieldGrams,
+    yieldLossPercent: input.recipe.yieldLossPercent,
+    items: input.items,
+  };
+  recipes.set(input.recipeId, liveRecipe);
+
+  const ctx: ResolverContext = {
+    ingredients: input.ctx.ingredients,
+    recipes,
+  };
+
+  try {
+    const resolved = resolveRecipeCost(input.recipeId, ctx);
+    return { ok: true, resolved };
+  } catch (err) {
+    const name = err instanceof Error ? err.name : "";
+    switch (name) {
+      case "RecipeCycleError":
+        return {
+          ok: false,
+          error: "Recept obsahuje cyklus",
+          code: "cycle",
+        };
+      case "RecipeDepthError":
+        return {
+          ok: false,
+          error: "Recept presahuje 3 úrovne subreceptov",
+          code: "depth",
+        };
+      case "RecipeNotFoundError":
+      case "IngredientNotFoundError":
+        return { ok: false, error: "Chýba ingrediencia", code: "missing" };
+      default:
+        return {
+          ok: false,
+          error: "Výpočet zlyhal",
+          code: "other",
+        };
+    }
+  }
+}
+
+/**
+ * Derive the set of allergen codes from a resolver run, sorted by
+ * canonical order. Re-exported here so client code doesn't need to
+ * pull the resolver's internals directly.
+ */
+export function allergensFromTrace(resolved: ResolvedRecipe): AllergenCode[] {
+  return resolved.allergenCodes;
+}

--- a/src/features/recipes/lib/cost-resolver.test.ts
+++ b/src/features/recipes/lib/cost-resolver.test.ts
@@ -1,0 +1,332 @@
+/* eslint-disable no-console */
+/**
+ * Resolver unit tests. Pure function, no DB. Run via:
+ *   pnpm dlx tsx src/features/recipes/lib/cost-resolver.test.ts
+ *
+ * Exits non-zero on any failure. No vitest dependency for now —
+ * keeps the PR scope small.
+ */
+import { strict as assert } from "node:assert/strict";
+import {
+  canAddSubRecipe,
+  type IngredientLite,
+  IngredientNotFoundError,
+  RecipeCycleError,
+  RecipeDepthError,
+  type RecipeLite,
+  RecipeNotFoundError,
+  resolveRecipeCost,
+} from "./cost-resolver";
+
+interface Case {
+  name: string;
+  run: () => void;
+}
+
+const cases: Case[] = [];
+const t = (name: string, run: () => void) => cases.push({ name, run });
+
+// --- fixtures ---------------------------------------------------------------
+
+const flour: IngredientLite = {
+  id: "ing_flour",
+  name: "Hladká múka T650",
+  baseUnit: "g",
+  gramsPerPiece: null,
+  pricePerKgCents: 120, // 1,20 € / kg
+  pricePerPieceCents: null,
+  allergenCodes: ["gluten"],
+};
+const water: IngredientLite = {
+  id: "ing_water",
+  name: "Voda",
+  baseUnit: "g",
+  gramsPerPiece: null,
+  pricePerKgCents: 0, // zero-priced; flags hasPrice = false
+  pricePerPieceCents: null,
+  allergenCodes: [],
+};
+const salt: IngredientLite = {
+  id: "ing_salt",
+  name: "Soľ",
+  baseUnit: "g",
+  gramsPerPiece: null,
+  pricePerKgCents: 50, // 0,50 € / kg
+  pricePerPieceCents: null,
+  allergenCodes: [],
+};
+const egg: IngredientLite = {
+  id: "ing_egg",
+  name: "Vajce M",
+  baseUnit: "piece",
+  gramsPerPiece: 50,
+  pricePerKgCents: null,
+  pricePerPieceCents: 20, // 0,20 € / piece
+  allergenCodes: ["eggs"],
+};
+
+// Final product recipe: 20 rolls per batch, 1500 g raw, 12% loss
+const recipeRoll: RecipeLite = {
+  id: "rec_roll",
+  name: "Rožok klasický",
+  batchYieldUnits: 20,
+  batchYieldGrams: 1500,
+  yieldLossPercent: 12,
+  items: [
+    { ingredientId: "ing_flour", subRecipeId: null, quantityBaseUnit: 1000 },
+    { ingredientId: "ing_water", subRecipeId: null, quantityBaseUnit: 600 },
+    { ingredientId: "ing_salt", subRecipeId: null, quantityBaseUnit: 20 },
+  ],
+};
+
+// Sub-recipe: kvások (sourdough starter) — 500 g batch, 50 g flour + 50 g water
+const recipeStarter: RecipeLite = {
+  id: "rec_starter",
+  name: "Kvások",
+  batchYieldUnits: 1,
+  batchYieldGrams: 100,
+  yieldLossPercent: 0,
+  items: [
+    { ingredientId: "ing_flour", subRecipeId: null, quantityBaseUnit: 50 },
+    { ingredientId: "ing_water", subRecipeId: null, quantityBaseUnit: 50 },
+  ],
+};
+
+// Recipe that uses kvások as a sub-recipe.
+const recipeStarterRoll: RecipeLite = {
+  id: "rec_starter_roll",
+  name: "Rožok s kváskom",
+  batchYieldUnits: 10,
+  batchYieldGrams: 1000,
+  yieldLossPercent: 10,
+  items: [
+    { ingredientId: "ing_flour", subRecipeId: null, quantityBaseUnit: 500 },
+    { ingredientId: null, subRecipeId: "rec_starter", quantityBaseUnit: 200 },
+  ],
+};
+
+// Recipe with eggs (piece-based)
+const recipePalacinka: RecipeLite = {
+  id: "rec_palacinka",
+  name: "Palacinky",
+  batchYieldUnits: 10,
+  batchYieldGrams: 800,
+  yieldLossPercent: 5,
+  items: [
+    { ingredientId: "ing_flour", subRecipeId: null, quantityBaseUnit: 250 },
+    { ingredientId: "ing_egg", subRecipeId: null, quantityBaseUnit: 3 },
+  ],
+};
+
+const baseCtx = () => ({
+  ingredients: new Map<string, IngredientLite>([
+    [flour.id, flour],
+    [water.id, water],
+    [salt.id, salt],
+    [egg.id, egg],
+  ]),
+  recipes: new Map<string, RecipeLite>([
+    [recipeRoll.id, recipeRoll],
+    [recipeStarter.id, recipeStarter],
+    [recipeStarterRoll.id, recipeStarterRoll],
+    [recipePalacinka.id, recipePalacinka],
+  ]),
+});
+
+// --- tests -----------------------------------------------------------------
+
+t("mass-based ingredient: cost = quantity_g * cents_per_kg / 1000", () => {
+  const ctx = baseCtx();
+  const r = resolveRecipeCost("rec_roll", ctx);
+  // flour: 1000g * 120c/kg / 1000 = 120c
+  // water: 0c (no price)
+  // salt: 20g * 50c/kg / 1000 = 1c
+  // batch = 121c, per unit = round(121/20) = 6c
+  assert.equal(r.batchCostCents, 121);
+  assert.equal(r.costPerUnitCents, 6);
+  assert.deepEqual(r.allergenCodes, ["gluten"]);
+});
+
+t("zero-priced ingredient is flagged but doesn't throw", () => {
+  const ctx = baseCtx();
+  const r = resolveRecipeCost("rec_roll", ctx);
+  const waterRow = r.trace.find((i) => i.refId === "ing_water");
+  assert.ok(waterRow);
+  assert.equal(waterRow.hasPrice, false);
+  assert.equal(waterRow.totalCostCents, 0);
+});
+
+t("piece-based ingredient: cost = quantity * cents_per_piece", () => {
+  const ctx = baseCtx();
+  const r = resolveRecipeCost("rec_palacinka", ctx);
+  // flour: 250g * 120 / 1000 = 30c
+  // egg: 3 * 20c = 60c
+  // batch = 90c
+  assert.equal(r.batchCostCents, 90);
+  assert.deepEqual(r.allergenCodes.sort(), ["eggs", "gluten"]);
+});
+
+t("piece-based mass contribution uses gramsPerPiece", () => {
+  const ctx = baseCtx();
+  const r = resolveRecipeCost("rec_palacinka", ctx);
+  const eggRow = r.trace.find((i) => i.refId === "ing_egg");
+  assert.ok(eggRow);
+  assert.equal(eggRow.massGrams, 150); // 3 * 50g
+});
+
+t("yield loss applied to finished mass", () => {
+  const ctx = baseCtx();
+  const r = resolveRecipeCost("rec_roll", ctx);
+  // 1500 * (1 - 12/100) = 1320
+  assert.equal(r.finishedMassGrams, 1320);
+});
+
+t("sub-recipe contributes per-gram cost", () => {
+  const ctx = baseCtx();
+  const r = resolveRecipeCost("rec_starter_roll", ctx);
+  // starter: flour 50g * 120/1000 = 6c, water 0, batch=6c, finishedMass=100g
+  // per gram of starter = 6/100 = 0.06c
+  // host uses 200g starter -> 200 * 0.06 = 12c
+  // host flour 500g * 120/1000 = 60c
+  // total = 72c
+  assert.equal(r.batchCostCents, 72);
+  assert.deepEqual(r.allergenCodes, ["gluten"]);
+});
+
+t("cycle detected: A -> B -> A", () => {
+  const ctx = baseCtx();
+  // Inject a cycle by making rec_starter reference rec_starter_roll.
+  ctx.recipes.set("rec_starter", {
+    ...recipeStarter,
+    items: [
+      ...recipeStarter.items,
+      {
+        ingredientId: null,
+        subRecipeId: "rec_starter_roll",
+        quantityBaseUnit: 10,
+      },
+    ],
+  });
+  assert.throws(
+    () => resolveRecipeCost("rec_starter_roll", ctx),
+    (err: Error) => err instanceof RecipeCycleError
+  );
+});
+
+t("depth exceeded: 4-level chain throws RecipeDepthError", () => {
+  const ctx = baseCtx();
+  // a -> b -> c -> d -> e (5 levels, exceeds MAX_RECIPE_DEPTH=3)
+  const chain = ["a", "b", "c", "d", "e"];
+  for (let i = 0; i < chain.length; i++) {
+    const next = chain[i + 1];
+    ctx.recipes.set(chain[i], {
+      id: chain[i],
+      name: chain[i],
+      batchYieldUnits: 1,
+      batchYieldGrams: 100,
+      yieldLossPercent: 0,
+      items: next
+        ? [{ ingredientId: null, subRecipeId: next, quantityBaseUnit: 10 }]
+        : [
+            {
+              ingredientId: "ing_flour",
+              subRecipeId: null,
+              quantityBaseUnit: 10,
+            },
+          ],
+    });
+  }
+  assert.throws(
+    () => resolveRecipeCost("a", ctx),
+    (err: Error) => err instanceof RecipeDepthError
+  );
+});
+
+t("missing ingredient throws IngredientNotFoundError", () => {
+  const ctx = baseCtx();
+  ctx.recipes.set("rec_dangling", {
+    id: "rec_dangling",
+    name: "Dangling",
+    batchYieldUnits: 1,
+    batchYieldGrams: 100,
+    yieldLossPercent: 0,
+    items: [
+      {
+        ingredientId: "ing_does_not_exist",
+        subRecipeId: null,
+        quantityBaseUnit: 100,
+      },
+    ],
+  });
+  assert.throws(
+    () => resolveRecipeCost("rec_dangling", ctx),
+    (err: Error) => err instanceof IngredientNotFoundError
+  );
+});
+
+t("missing recipe throws RecipeNotFoundError", () => {
+  const ctx = baseCtx();
+  assert.throws(
+    () => resolveRecipeCost("rec_does_not_exist", ctx),
+    (err: Error) => err instanceof RecipeNotFoundError
+  );
+});
+
+t("canAddSubRecipe: self rejected", () => {
+  const r = canAddSubRecipe("a", "a", new Map());
+  assert.deepEqual(r, { ok: false, reason: "self" });
+});
+
+t("canAddSubRecipe: ok for unrelated leaves", () => {
+  const graph = new Map<string, readonly string[]>([
+    ["a", []],
+    ["b", []],
+  ]);
+  assert.deepEqual(canAddSubRecipe("a", "b", graph), { ok: true });
+});
+
+t("canAddSubRecipe: cycle when candidate uses host transitively", () => {
+  // host a, candidate b which uses c which uses a.
+  const graph = new Map<string, readonly string[]>([
+    ["a", []],
+    ["b", ["c"]],
+    ["c", ["a"]],
+  ]);
+  assert.deepEqual(canAddSubRecipe("a", "b", graph), {
+    ok: false,
+    reason: "cycle",
+  });
+});
+
+t("canAddSubRecipe: depth exceeded when adding would push past 3", () => {
+  // host already at depth 2; candidate has its own 2-level chain.
+  const graph = new Map<string, readonly string[]>([
+    ["a", []],
+    ["x", ["y"]],
+    ["y", []],
+  ]);
+  const r = canAddSubRecipe("a", "x", graph, 3);
+  assert.equal(r.ok, false);
+});
+
+// --- runner -----------------------------------------------------------------
+
+let pass = 0;
+let fail = 0;
+for (const c of cases) {
+  try {
+    c.run();
+    console.log(`  ✓ ${c.name}`);
+    pass++;
+  } catch (err) {
+    console.error(`  ✗ ${c.name}`);
+    console.error(err);
+    fail++;
+  }
+}
+console.log(
+  `\nResolver: ${pass} passed, ${fail} failed (${cases.length} total)`
+);
+if (fail > 0) {
+  process.exit(1);
+}

--- a/src/features/recipes/lib/cost-resolver.test.ts
+++ b/src/features/recipes/lib/cost-resolver.test.ts
@@ -298,6 +298,73 @@ t("canAddSubRecipe: cycle when candidate uses host transitively", () => {
   });
 });
 
+// --- Phase D: nutrition tests ---
+
+t(
+  "nutrition: per-100g flows from ingredients into batch + per-100g output",
+  () => {
+    const ctx = baseCtx();
+    // Add nutrition to flour: 360 kcal/100g, 10g protein/100g
+    ctx.ingredients.set("ing_flour", {
+      ...flour,
+      nutritionPer100: {
+        kcal: 360,
+        protein: 10,
+        fat: 1,
+        saturatedFat: 0.2,
+        carbs: 75,
+        sugar: 0.3,
+        salt: 0.01,
+        fiber: 2.5,
+      },
+    });
+    const r = resolveRecipeCost("rec_roll", ctx);
+    // flour: 1000g; scale = 1000/100 = 10x → 3600 kcal contribution
+    // water + salt have no nutrition → contribute 0; nutritionIncomplete = true
+    assert.equal(r.nutritionIncomplete, true);
+    assert.equal(r.batchNutrition.kcal, 3600);
+    // finished mass = 1320g; per-100g = 3600 / 1320 * 100 ≈ 273
+    assert.equal(r.nutritionPer100.kcal, 273);
+  }
+);
+
+t(
+  "nutrition: ingredient without nutritionPer100 contributes zero, flagged",
+  () => {
+    const ctx = baseCtx();
+    const r = resolveRecipeCost("rec_roll", ctx);
+    assert.equal(r.batchNutrition.kcal, 0);
+    assert.equal(r.nutritionIncomplete, true);
+    // All trace items should have hasNutrition = false
+    for (const t of r.trace) {
+      assert.equal(t.hasNutrition, false);
+    }
+  }
+);
+
+t("nutrition: piece-based item uses gramsPerPiece for mass", () => {
+  const ctx = baseCtx();
+  ctx.ingredients.set("ing_egg", {
+    ...egg,
+    nutritionPer100: {
+      kcal: 140,
+      protein: 12,
+      fat: 9.5,
+      saturatedFat: 3,
+      carbs: 1,
+      sugar: 1,
+      salt: 0.4,
+      fiber: 0,
+    },
+  });
+  const r = resolveRecipeCost("rec_palacinka", ctx);
+  // egg: 3 pieces * 50g = 150g; 150/100 = 1.5x → 210 kcal contribution
+  const eggRow = r.trace.find((i) => i.refId === "ing_egg");
+  assert.ok(eggRow);
+  assert.equal(eggRow.hasNutrition, true);
+  assert.equal(eggRow.contributedNutrition.kcal, 210);
+});
+
 t("canAddSubRecipe: depth exceeded when adding would push past 3", () => {
   // host already at depth 2; candidate has its own 2-level chain.
   const graph = new Map<string, readonly string[]>([

--- a/src/features/recipes/lib/cost-resolver.ts
+++ b/src/features/recipes/lib/cost-resolver.ts
@@ -1,0 +1,323 @@
+/**
+ * Pure-function cost resolver. Single source of truth for cost +
+ * (Phase D) nutrition + allergen derivation from a recipe.
+ *
+ * Used by:
+ * - Server actions (authoritative compute on save and at order creation)
+ * - Client preview panel (instant feedback during edit)
+ *
+ * Pricing model: cents/kg (mass) or cents/piece (piece). See
+ * docs/specs/_arc-overview.md §3.
+ *
+ * NEVER throws for missing/zero prices — those degrade to zero
+ * contribution + a flag in the trace. Only throws for cycle, depth
+ * exceeded, or genuinely missing references.
+ */
+
+import type { AllergenCode } from "@/features/allergens/schema";
+
+export const MAX_RECIPE_DEPTH = 3;
+
+export interface IngredientLite {
+  allergenCodes: readonly AllergenCode[];
+  baseUnit: "g" | "piece";
+  gramsPerPiece: number | null;
+  id: string;
+  name: string;
+  pricePerKgCents: number | null;
+  pricePerPieceCents: number | null;
+}
+
+export interface RecipeLite {
+  batchYieldGrams: number;
+  batchYieldUnits: number;
+  id: string;
+  items: readonly RecipeItemLite[];
+  name: string;
+  yieldLossPercent: number;
+}
+
+export interface RecipeItemLite {
+  id?: string;
+  ingredientId: string | null;
+  quantityBaseUnit: number;
+  subRecipeId: string | null;
+}
+
+export interface ResolverContext {
+  ingredients: ReadonlyMap<string, IngredientLite>;
+  recipes: ReadonlyMap<string, RecipeLite>;
+}
+
+export interface ResolvedRecipeItem {
+  allergenCodes: readonly AllergenCode[];
+  /** False when the ingredient/sub-recipe has no usable price. */
+  hasPrice: boolean;
+  itemId?: string;
+  kind: "ingredient" | "sub_recipe";
+  /** Mass contribution in grams (used by Phase D for nutrition math). */
+  massGrams: number;
+  quantityBaseUnit: number;
+  refId: string;
+  refName: string;
+  /** Total cost contribution to the parent batch, in cents. */
+  totalCostCents: number;
+  /** Unit cost in cents (per kg or per piece for ingredients, per gram for sub-recipes). */
+  unitCostCents: number;
+}
+
+export interface ResolvedRecipe {
+  allergenCodes: AllergenCode[];
+  batchCostCents: number;
+  costPerUnitCents: number;
+  finishedMassGrams: number;
+  recipeId: string;
+  trace: ResolvedRecipeItem[];
+}
+
+export class RecipeCycleError extends Error {
+  readonly recipeId: string;
+  readonly path: string[];
+  constructor(recipeId: string, path: string[]) {
+    super(`Recipe ${recipeId} forms a cycle through [${path.join(" -> ")}]`);
+    this.name = "RecipeCycleError";
+    this.recipeId = recipeId;
+    this.path = path;
+  }
+}
+
+export class RecipeDepthError extends Error {
+  readonly recipeId: string;
+  constructor(recipeId: string) {
+    super(
+      `Recipe ${recipeId} exceeds the max recipe depth of ${MAX_RECIPE_DEPTH}`
+    );
+    this.name = "RecipeDepthError";
+    this.recipeId = recipeId;
+  }
+}
+
+export class RecipeNotFoundError extends Error {
+  readonly recipeId: string;
+  constructor(recipeId: string) {
+    super(`Recipe ${recipeId} not found in resolver context`);
+    this.name = "RecipeNotFoundError";
+    this.recipeId = recipeId;
+  }
+}
+
+export class IngredientNotFoundError extends Error {
+  readonly ingredientId: string;
+  constructor(ingredientId: string) {
+    super(`Ingredient ${ingredientId} not found in resolver context`);
+    this.name = "IngredientNotFoundError";
+    this.ingredientId = ingredientId;
+  }
+}
+
+/**
+ * Compute cost + allergens for the recipe. Recurses through sub-recipes
+ * with cycle + depth guards.
+ *
+ * @throws RecipeCycleError when a cycle is detected
+ * @throws RecipeDepthError when MAX_RECIPE_DEPTH is exceeded
+ * @throws RecipeNotFoundError / IngredientNotFoundError for dangling refs
+ */
+export function resolveRecipeCost(
+  recipeId: string,
+  ctx: ResolverContext,
+  visited: ReadonlySet<string> = new Set()
+): ResolvedRecipe {
+  if (visited.has(recipeId)) {
+    throw new RecipeCycleError(recipeId, [...visited]);
+  }
+  if (visited.size >= MAX_RECIPE_DEPTH) {
+    throw new RecipeDepthError(recipeId);
+  }
+
+  const recipe = ctx.recipes.get(recipeId);
+  if (!recipe) {
+    throw new RecipeNotFoundError(recipeId);
+  }
+
+  const nextVisited = new Set(visited);
+  nextVisited.add(recipeId);
+
+  let batchCostCents = 0;
+  const allergens = new Set<AllergenCode>();
+  const trace: ResolvedRecipeItem[] = [];
+
+  for (const item of recipe.items) {
+    const resolved = resolveOneItem(item, ctx, nextVisited);
+    if (resolved) {
+      trace.push(resolved);
+      batchCostCents += resolved.totalCostCents;
+      for (const c of resolved.allergenCodes) {
+        allergens.add(c);
+      }
+    }
+  }
+
+  const finishedMassGrams = Math.round(
+    recipe.batchYieldGrams * (1 - recipe.yieldLossPercent / 100)
+  );
+  const costPerUnitCents = Math.round(
+    batchCostCents / Math.max(recipe.batchYieldUnits, 1)
+  );
+
+  return {
+    recipeId,
+    batchCostCents,
+    costPerUnitCents,
+    allergenCodes: [...allergens].sort(),
+    finishedMassGrams,
+    trace,
+  };
+}
+
+function resolveOneItem(
+  item: RecipeItemLite,
+  ctx: ResolverContext,
+  visited: ReadonlySet<string>
+): ResolvedRecipeItem | null {
+  if (item.ingredientId) {
+    const ing = ctx.ingredients.get(item.ingredientId);
+    if (!ing) {
+      throw new IngredientNotFoundError(item.ingredientId);
+    }
+    return resolveIngredientItem(ing, item);
+  }
+  if (item.subRecipeId) {
+    const sub = resolveRecipeCost(item.subRecipeId, ctx, visited);
+    return resolveSubRecipeItem(sub, item);
+  }
+  return null;
+}
+
+function resolveIngredientItem(
+  ing: IngredientLite,
+  item: RecipeItemLite
+): ResolvedRecipeItem {
+  let totalCostCents = 0;
+  let unitCostCents = 0;
+  let hasPrice = false;
+  let massGrams = 0;
+
+  if (ing.baseUnit === "g") {
+    massGrams = item.quantityBaseUnit;
+    if (ing.pricePerKgCents !== null && ing.pricePerKgCents > 0) {
+      unitCostCents = ing.pricePerKgCents;
+      totalCostCents = Math.round(
+        (item.quantityBaseUnit * ing.pricePerKgCents) / 1000
+      );
+      hasPrice = true;
+    }
+  } else {
+    // piece-based
+    massGrams = item.quantityBaseUnit * (ing.gramsPerPiece ?? 0);
+    if (ing.pricePerPieceCents !== null && ing.pricePerPieceCents > 0) {
+      unitCostCents = ing.pricePerPieceCents;
+      totalCostCents = item.quantityBaseUnit * ing.pricePerPieceCents;
+      hasPrice = true;
+    }
+  }
+
+  return {
+    itemId: item.id,
+    kind: "ingredient",
+    refId: ing.id,
+    refName: ing.name,
+    quantityBaseUnit: item.quantityBaseUnit,
+    unitCostCents,
+    totalCostCents,
+    allergenCodes: ing.allergenCodes,
+    hasPrice,
+    massGrams,
+  };
+}
+
+function resolveSubRecipeItem(
+  sub: ResolvedRecipe,
+  item: RecipeItemLite
+): ResolvedRecipeItem {
+  // Sub-recipes are consumed by mass (grams).
+  const massGrams = item.quantityBaseUnit;
+  let unitCostCents = 0;
+  let totalCostCents = 0;
+  let hasPrice = false;
+
+  if (sub.finishedMassGrams > 0 && sub.batchCostCents > 0) {
+    // Per-gram cost of the sub-recipe times the quantity used.
+    const subPerGramHundredths =
+      (sub.batchCostCents * 100) / sub.finishedMassGrams;
+    unitCostCents = Math.round(subPerGramHundredths / 100);
+    totalCostCents = Math.round((subPerGramHundredths * massGrams) / 100);
+    hasPrice = true;
+  }
+
+  return {
+    itemId: item.id,
+    kind: "sub_recipe",
+    refId: sub.recipeId,
+    refName: "",
+    quantityBaseUnit: item.quantityBaseUnit,
+    unitCostCents,
+    totalCostCents,
+    allergenCodes: sub.allergenCodes,
+    hasPrice,
+    massGrams,
+  };
+}
+
+/**
+ * Cycle/depth pre-check used by the picker to filter out invalid
+ * sub-recipe choices BEFORE the resolver runs. Returns ok:false with a
+ * reason that the UI can render directly.
+ */
+export type CanAddResult =
+  | { ok: true }
+  | { ok: false; reason: "self" | "cycle" | "depth" };
+
+export function canAddSubRecipe(
+  hostRecipeId: string,
+  candidateSubRecipeId: string,
+  recipesGraph: ReadonlyMap<string, readonly string[]>,
+  currentDepth = 0
+): CanAddResult {
+  if (hostRecipeId === candidateSubRecipeId) {
+    return { ok: false, reason: "self" };
+  }
+
+  if (currentDepth >= MAX_RECIPE_DEPTH) {
+    return { ok: false, reason: "depth" };
+  }
+
+  // Walk the candidate's tree; if we ever see the host, that's a cycle.
+  const stack: Array<{ id: string; d: number }> = [
+    { id: candidateSubRecipeId, d: currentDepth + 1 },
+  ];
+  const seen = new Set<string>();
+  while (stack.length > 0) {
+    const top = stack.pop();
+    if (!top) {
+      break;
+    }
+    const { id, d } = top;
+    if (seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    if (id === hostRecipeId) {
+      return { ok: false, reason: "cycle" };
+    }
+    if (d >= MAX_RECIPE_DEPTH) {
+      return { ok: false, reason: "depth" };
+    }
+    const children = recipesGraph.get(id) ?? [];
+    for (const child of children) {
+      stack.push({ id: child, d: d + 1 });
+    }
+  }
+
+  return { ok: true };
+}

--- a/src/features/recipes/lib/cost-resolver.ts
+++ b/src/features/recipes/lib/cost-resolver.ts
@@ -15,6 +15,13 @@
  */
 
 import type { AllergenCode } from "@/features/allergens/schema";
+import type { NutritionPer100Schema } from "@/features/ingredients/schema";
+import {
+  roundNutrition,
+  scaleNutrition,
+  sumNutrition,
+  ZERO_NUTRITION,
+} from "./nutrition-math";
 
 export const MAX_RECIPE_DEPTH = 3;
 
@@ -24,6 +31,8 @@ export interface IngredientLite {
   gramsPerPiece: number | null;
   id: string;
   name: string;
+  /** Phase D: nutrition per 100 g; null when admin hasn't filled it yet. */
+  nutritionPer100?: NutritionPer100Schema | null;
   pricePerKgCents: number | null;
   pricePerPieceCents: number | null;
 }
@@ -51,11 +60,15 @@ export interface ResolverContext {
 
 export interface ResolvedRecipeItem {
   allergenCodes: readonly AllergenCode[];
+  /** Phase D: nutrition contributed by this item to the parent batch (absolute g / kcal). */
+  contributedNutrition: NutritionPer100Schema;
+  /** Phase D: false when the ingredient has no nutrition data. */
+  hasNutrition: boolean;
   /** False when the ingredient/sub-recipe has no usable price. */
   hasPrice: boolean;
   itemId?: string;
   kind: "ingredient" | "sub_recipe";
-  /** Mass contribution in grams (used by Phase D for nutrition math). */
+  /** Mass contribution in grams. */
   massGrams: number;
   quantityBaseUnit: number;
   refId: string;
@@ -69,8 +82,14 @@ export interface ResolvedRecipeItem {
 export interface ResolvedRecipe {
   allergenCodes: AllergenCode[];
   batchCostCents: number;
+  /** Phase D: nutrition for the whole batch (sum of items, absolute). */
+  batchNutrition: NutritionPer100Schema;
   costPerUnitCents: number;
   finishedMassGrams: number;
+  /** Phase D: true when any item lacked nutrition data; preview surfaces a warning. */
+  nutritionIncomplete: boolean;
+  /** Phase D: nutrition per 100 g of finished product (final display value). */
+  nutritionPer100: NutritionPer100Schema;
   recipeId: string;
   trace: ResolvedRecipeItem[];
 }
@@ -144,6 +163,8 @@ export function resolveRecipeCost(
   nextVisited.add(recipeId);
 
   let batchCostCents = 0;
+  let batchNutrition = { ...ZERO_NUTRITION };
+  let nutritionIncomplete = false;
   const allergens = new Set<AllergenCode>();
   const trace: ResolvedRecipeItem[] = [];
 
@@ -152,6 +173,13 @@ export function resolveRecipeCost(
     if (resolved) {
       trace.push(resolved);
       batchCostCents += resolved.totalCostCents;
+      batchNutrition = sumNutrition(
+        batchNutrition,
+        resolved.contributedNutrition
+      );
+      if (!resolved.hasNutrition) {
+        nutritionIncomplete = true;
+      }
       for (const c of resolved.allergenCodes) {
         allergens.add(c);
       }
@@ -164,6 +192,10 @@ export function resolveRecipeCost(
   const costPerUnitCents = Math.round(
     batchCostCents / Math.max(recipe.batchYieldUnits, 1)
   );
+  const nutritionPer100 =
+    finishedMassGrams > 0
+      ? roundNutrition(scaleNutrition(batchNutrition, 100 / finishedMassGrams))
+      : { ...ZERO_NUTRITION };
 
   return {
     recipeId,
@@ -172,6 +204,9 @@ export function resolveRecipeCost(
     allergenCodes: [...allergens].sort(),
     finishedMassGrams,
     trace,
+    batchNutrition,
+    nutritionPer100,
+    nutritionIncomplete,
   };
 }
 
@@ -222,6 +257,14 @@ function resolveIngredientItem(
     }
   }
 
+  // Nutrition contribution: ingredient's per-100g values scaled by massGrams.
+  let contributedNutrition = { ...ZERO_NUTRITION };
+  let hasNutrition = false;
+  if (ing.nutritionPer100 && massGrams > 0) {
+    contributedNutrition = scaleNutrition(ing.nutritionPer100, massGrams / 100);
+    hasNutrition = true;
+  }
+
   return {
     itemId: item.id,
     kind: "ingredient",
@@ -232,7 +275,9 @@ function resolveIngredientItem(
     totalCostCents,
     allergenCodes: ing.allergenCodes,
     hasPrice,
+    hasNutrition,
     massGrams,
+    contributedNutrition,
   };
 }
 
@@ -255,6 +300,15 @@ function resolveSubRecipeItem(
     hasPrice = true;
   }
 
+  // Sub-recipe nutrition is scaled by mass fraction.
+  let contributedNutrition = { ...ZERO_NUTRITION };
+  let hasNutrition = false;
+  if (sub.finishedMassGrams > 0 && !sub.nutritionIncomplete) {
+    const fraction = massGrams / sub.finishedMassGrams;
+    contributedNutrition = scaleNutrition(sub.batchNutrition, fraction);
+    hasNutrition = true;
+  }
+
   return {
     itemId: item.id,
     kind: "sub_recipe",
@@ -265,7 +319,9 @@ function resolveSubRecipeItem(
     totalCostCents,
     allergenCodes: sub.allergenCodes,
     hasPrice,
+    hasNutrition,
     massGrams,
+    contributedNutrition,
   };
 }
 

--- a/src/features/recipes/lib/nutrition-math.ts
+++ b/src/features/recipes/lib/nutrition-math.ts
@@ -1,0 +1,75 @@
+import type { NutritionPer100Schema } from "@/features/ingredients/schema";
+
+export const ZERO_NUTRITION: NutritionPer100Schema = {
+  kcal: 0,
+  protein: 0,
+  fat: 0,
+  saturatedFat: 0,
+  carbs: 0,
+  sugar: 0,
+  salt: 0,
+  fiber: 0,
+};
+
+const KEYS: Array<keyof NutritionPer100Schema> = [
+  "kcal",
+  "protein",
+  "fat",
+  "saturatedFat",
+  "carbs",
+  "sugar",
+  "salt",
+  "fiber",
+];
+
+/** Scale every field by the given factor. */
+export function scaleNutrition(
+  n: NutritionPer100Schema,
+  factor: number
+): NutritionPer100Schema {
+  const out = { ...ZERO_NUTRITION };
+  for (const k of KEYS) {
+    out[k] = n[k] * factor;
+  }
+  return out;
+}
+
+/** Element-wise sum. */
+export function sumNutrition(
+  a: NutritionPer100Schema,
+  b: NutritionPer100Schema
+): NutritionPer100Schema {
+  const out = { ...ZERO_NUTRITION };
+  for (const k of KEYS) {
+    out[k] = a[k] + b[k];
+  }
+  return out;
+}
+
+/** Round all values to sensible precision for storage / display. */
+export function roundNutrition(
+  n: NutritionPer100Schema
+): NutritionPer100Schema {
+  return {
+    kcal: Math.round(n.kcal),
+    protein: round1(n.protein),
+    fat: round1(n.fat),
+    saturatedFat: round1(n.saturatedFat),
+    carbs: round1(n.carbs),
+    sugar: round1(n.sugar),
+    salt: round2(n.salt),
+    fiber: round1(n.fiber),
+  };
+}
+
+function round1(x: number): number {
+  return Math.round(x * 10) / 10;
+}
+function round2(x: number): number {
+  return Math.round(x * 100) / 100;
+}
+
+/** kJ from kcal via the standard 4.184 multiplier. */
+export function kJFromKcal(kcal: number): number {
+  return Math.round(kcal * 4.184);
+}

--- a/src/features/recipes/schema.ts
+++ b/src/features/recipes/schema.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+import { RECIPE_KINDS, RECIPE_STATUSES } from "@/db/schema";
+
+export const recipeHeaderSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "Názov je povinný")
+    .max(100, "Názov je príliš dlhý"),
+  slug: z.string().trim().min(1).max(120),
+  kind: z.enum(RECIPE_KINDS),
+  status: z.enum(RECIPE_STATUSES),
+  batchYieldUnits: z.number().int().positive("Výnos musí byť kladné číslo"),
+  batchYieldGrams: z.number().int().min(0),
+  yieldLossPercent: z.number().int().min(0).max(50),
+  notes: z.string().trim().max(2000).nullable(),
+});
+
+export type RecipeHeaderSchema = z.infer<typeof recipeHeaderSchema>;
+
+export const addRecipeItemSchema = z
+  .object({
+    recipeId: z.string().min(1),
+    ingredientId: z.string().min(1).nullable(),
+    subRecipeId: z.string().min(1).nullable(),
+    quantityBaseUnit: z.number().int().positive(),
+  })
+  .refine(
+    (v) => Boolean(v.ingredientId) !== Boolean(v.subRecipeId),
+    "Buď ingrediencia alebo subrecept, nie oboje"
+  );
+
+export type AddRecipeItemSchema = z.infer<typeof addRecipeItemSchema>;
+
+export const updateRecipeItemSchema = z.object({
+  itemId: z.string().min(1),
+  quantityBaseUnit: z.number().int().positive(),
+});
+
+export type UpdateRecipeItemSchema = z.infer<typeof updateRecipeItemSchema>;
+
+export const removeRecipeItemSchema = z.object({
+  itemId: z.string().min(1),
+});
+
+export const reorderRecipeItemsSchema = z.object({
+  recipeId: z.string().min(1),
+  orderedItemIds: z.array(z.string().min(1)).min(1),
+});
+
+export const linkProductRecipeSchema = z.object({
+  productId: z.string().min(1),
+  recipeId: z.string().min(1).nullable(),
+});
+
+export type LinkProductRecipeSchema = z.infer<typeof linkProductRecipeSchema>;

--- a/src/features/reports/api/exports.ts
+++ b/src/features/reports/api/exports.ts
@@ -1,0 +1,94 @@
+import "server-only";
+
+import type { Period } from "../lib/period";
+import { getProductProfitability, getStoreProfitability } from "./queries";
+
+const CSV_NEEDS_QUOTING_RE = /[";\n]/;
+const CSV_DOUBLE_QUOTE_RE = /"/g;
+
+/**
+ * CSV serializer for Slovak Excel: UTF-8 BOM, semicolon delimiter,
+ * decimal comma. Caller wraps with the Response/Content-Disposition.
+ */
+function escapeCsv(value: string): string {
+  if (CSV_NEEDS_QUOTING_RE.test(value)) {
+    return `"${value.replace(CSV_DOUBLE_QUOTE_RE, '""')}"`;
+  }
+  return value;
+}
+
+function n(cents: number | null): string {
+  if (cents === null) {
+    return "";
+  }
+  return (cents / 100).toFixed(2).replace(".", ",");
+}
+
+function pct(value: number | null): string {
+  if (value === null) {
+    return "";
+  }
+  return value.toFixed(1).replace(".", ",");
+}
+
+const BOM = "﻿";
+
+export async function exportStoreProfitabilityCsv(
+  period: Period
+): Promise<string> {
+  const rows = await getStoreProfitability(period);
+  const header = [
+    "Predajňa",
+    "Objednávky",
+    "Tržby (€)",
+    "Náklady (€)",
+    "Marža (€)",
+    "Marža (%)",
+    "Objednávky bez nákladov",
+  ];
+  const lines = [
+    header.map(escapeCsv).join(";"),
+    ...rows.map((r) =>
+      [
+        escapeCsv(r.storeName ?? "(bez predajne)"),
+        String(r.orderCount),
+        n(r.revenueCents),
+        n(r.costCents),
+        n(r.marginCents),
+        pct(r.marginPct),
+        String(r.untrackedCostOrderCount),
+      ].join(";")
+    ),
+  ];
+  return BOM + lines.join("\n");
+}
+
+export async function exportProductProfitabilityCsv(
+  period: Period
+): Promise<string> {
+  const rows = await getProductProfitability(period);
+  const header = [
+    "Produkt",
+    "Kategória",
+    "Predané ks",
+    "Tržby (€)",
+    "Náklady (€)",
+    "Marža (€)",
+    "Marža (%)",
+  ];
+  const lines = [
+    header.map(escapeCsv).join(";"),
+    ...rows.map((r) =>
+      [
+        escapeCsv(r.productName),
+        escapeCsv(r.categoryName ?? ""),
+        String(r.quantitySold),
+        n(r.revenueCents),
+        n(r.costCents),
+        n(r.marginCents),
+        pct(r.marginPct),
+      ].join(";")
+    ),
+  ];
+  return BOM + lines.join("\n");
+}

--- a/src/features/reports/api/queries.ts
+++ b/src/features/reports/api/queries.ts
@@ -1,0 +1,219 @@
+"use cache";
+
+import { sql } from "drizzle-orm";
+import { cacheLife, cacheTag } from "next/cache";
+import { db } from "@/db";
+import { PROFIT_ORDER_STATUSES } from "../lib/constants";
+import type { Period } from "../lib/period";
+
+export interface StoreProfitabilityRow {
+  costCents: number | null;
+  marginCents: number | null;
+  marginPct: number | null;
+  orderCount: number;
+  revenueCents: number;
+  storeId: string | null;
+  storeName: string | null;
+  untrackedCostOrderCount: number;
+}
+
+export interface ProductProfitabilityRow {
+  categoryName: string | null;
+  costCents: number | null;
+  marginCents: number | null;
+  marginPct: number | null;
+  productId: string;
+  productName: string;
+  quantitySold: number;
+  revenueCents: number;
+}
+
+export interface ProfitabilitySummary {
+  costCents: number | null;
+  marginCents: number | null;
+  marginPct: number | null;
+  orderCount: number;
+  revenueCents: number;
+  untrackedShare: number;
+}
+
+interface FilterOpts {
+  storeIds?: string[];
+}
+
+/**
+ * Total revenue / cost / margin for the period. Used by the dashboard
+ * widget and the summary KPI strip on every report.
+ */
+export async function getProfitabilitySummary(
+  period: Period,
+  opts: FilterOpts = {}
+): Promise<ProfitabilitySummary> {
+  cacheLife("hours");
+  cacheTag("reports", "reports-summary", "orders");
+
+  const rows = await db.execute(sql`
+    SELECT
+      COALESCE(SUM(oi.price * oi.quantity), 0)::int AS revenue_cents,
+      SUM(oi.unit_cost_cents * oi.quantity) FILTER (WHERE oi.unit_cost_cents IS NOT NULL)::int AS cost_cents,
+      COUNT(DISTINCT o.id)::int AS order_count,
+      COUNT(DISTINCT o.id) FILTER (WHERE oi.unit_cost_cents IS NULL)::int AS untracked_count
+    FROM orders o
+    JOIN order_items oi ON oi.order_id = o.id
+    WHERE o.created_at >= ${period.from}
+      AND o.created_at <= ${period.to}
+      AND o.order_status = ANY(${[...PROFIT_ORDER_STATUSES]})
+      AND (${opts.storeIds ? opts.storeIds : null}::text[] IS NULL OR o.store_id = ANY(${opts.storeIds ?? []}))
+  `);
+
+  const row = rows.rows[0] as
+    | {
+        revenue_cents: number;
+        cost_cents: number | null;
+        order_count: number;
+        untracked_count: number;
+      }
+    | undefined;
+  if (!row) {
+    return {
+      revenueCents: 0,
+      costCents: null,
+      marginCents: null,
+      marginPct: null,
+      orderCount: 0,
+      untrackedShare: 0,
+    };
+  }
+
+  const marginCents =
+    row.cost_cents === null ? null : row.revenue_cents - row.cost_cents;
+  const marginPct =
+    marginCents === null || row.revenue_cents === 0
+      ? null
+      : (marginCents / row.revenue_cents) * 100;
+  const untrackedShare =
+    row.order_count > 0 ? row.untracked_count / row.order_count : 0;
+
+  return {
+    revenueCents: row.revenue_cents,
+    costCents: row.cost_cents,
+    marginCents,
+    marginPct,
+    orderCount: row.order_count,
+    untrackedShare,
+  };
+}
+
+export async function getStoreProfitability(
+  period: Period,
+  opts: FilterOpts = {}
+): Promise<StoreProfitabilityRow[]> {
+  cacheLife("hours");
+  cacheTag("reports", "reports-stores", "orders");
+
+  const rows = await db.execute(sql`
+    SELECT
+      o.store_id,
+      s.name AS store_name,
+      COUNT(DISTINCT o.id)::int AS order_count,
+      COALESCE(SUM(oi.price * oi.quantity), 0)::int AS revenue_cents,
+      SUM(oi.unit_cost_cents * oi.quantity) FILTER (WHERE oi.unit_cost_cents IS NOT NULL)::int AS cost_cents,
+      COUNT(DISTINCT o.id) FILTER (WHERE oi.unit_cost_cents IS NULL)::int AS untracked_count
+    FROM orders o
+    JOIN order_items oi ON oi.order_id = o.id
+    LEFT JOIN stores s ON s.id = o.store_id
+    WHERE o.created_at >= ${period.from}
+      AND o.created_at <= ${period.to}
+      AND o.order_status = ANY(${[...PROFIT_ORDER_STATUSES]})
+      AND (${opts.storeIds ? opts.storeIds : null}::text[] IS NULL OR o.store_id = ANY(${opts.storeIds ?? []}))
+    GROUP BY o.store_id, s.name
+    ORDER BY revenue_cents DESC NULLS LAST
+  `);
+
+  return (
+    rows.rows as Array<{
+      store_id: string | null;
+      store_name: string | null;
+      order_count: number;
+      revenue_cents: number;
+      cost_cents: number | null;
+      untracked_count: number;
+    }>
+  ).map((r) => {
+    const marginCents =
+      r.cost_cents === null ? null : r.revenue_cents - r.cost_cents;
+    const marginPct =
+      marginCents === null || r.revenue_cents === 0
+        ? null
+        : (marginCents / r.revenue_cents) * 100;
+    return {
+      storeId: r.store_id,
+      storeName: r.store_name,
+      orderCount: r.order_count,
+      revenueCents: r.revenue_cents,
+      costCents: r.cost_cents,
+      marginCents,
+      marginPct,
+      untrackedCostOrderCount: r.untracked_count,
+    };
+  });
+}
+
+export async function getProductProfitability(
+  period: Period,
+  opts: FilterOpts & { minQuantity?: number } = {}
+): Promise<ProductProfitabilityRow[]> {
+  cacheLife("hours");
+  cacheTag("reports", "reports-products", "orders");
+
+  const minQty = opts.minQuantity ?? 0;
+  const rows = await db.execute(sql`
+    SELECT
+      oi.product_id,
+      COALESCE(p.name, oi.product_id) AS product_name,
+      c.name AS category_name,
+      SUM(oi.quantity)::int AS quantity_sold,
+      COALESCE(SUM(oi.price * oi.quantity), 0)::int AS revenue_cents,
+      SUM(oi.unit_cost_cents * oi.quantity) FILTER (WHERE oi.unit_cost_cents IS NOT NULL)::int AS cost_cents
+    FROM orders o
+    JOIN order_items oi ON oi.order_id = o.id
+    LEFT JOIN products p ON p.id = oi.product_id
+    LEFT JOIN categories c ON c.id = p.category_id
+    WHERE o.created_at >= ${period.from}
+      AND o.created_at <= ${period.to}
+      AND o.order_status = ANY(${[...PROFIT_ORDER_STATUSES]})
+      AND (${opts.storeIds ? opts.storeIds : null}::text[] IS NULL OR o.store_id = ANY(${opts.storeIds ?? []}))
+    GROUP BY oi.product_id, p.name, c.name
+    HAVING SUM(oi.quantity) >= ${minQty}
+    ORDER BY revenue_cents DESC
+    LIMIT 500
+  `);
+
+  return (
+    rows.rows as Array<{
+      product_id: string;
+      product_name: string;
+      category_name: string | null;
+      quantity_sold: number;
+      revenue_cents: number;
+      cost_cents: number | null;
+    }>
+  ).map((r) => {
+    const marginCents =
+      r.cost_cents === null ? null : r.revenue_cents - r.cost_cents;
+    const marginPct =
+      marginCents === null || r.revenue_cents === 0
+        ? null
+        : (marginCents / r.revenue_cents) * 100;
+    return {
+      productId: r.product_id,
+      productName: r.product_name,
+      categoryName: r.category_name,
+      quantitySold: r.quantity_sold,
+      revenueCents: r.revenue_cents,
+      costCents: r.cost_cents,
+      marginCents,
+      marginPct,
+    };
+  });
+}

--- a/src/features/reports/components/dashboard-profit-widget.tsx
+++ b/src/features/reports/components/dashboard-profit-widget.tsx
@@ -1,0 +1,60 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { getProfitabilitySummary } from "../api/queries";
+import { formatEur, formatPct, marginColor } from "../lib/format";
+import { resolvePeriod } from "../lib/period";
+
+/**
+ * Last-30-days profitability summary card. Drops into the admin
+ * landing page so admins see "did we make money" without navigating.
+ */
+export async function DashboardProfitWidget() {
+  const period = resolvePeriod("30d");
+  const summary = await getProfitabilitySummary(period);
+
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="font-semibold text-sm">Ziskovosť (30 dní)</p>
+          <p className="text-muted-foreground text-xs">
+            Hrubá marža bez réžie a miezd.
+          </p>
+        </div>
+        <Button asChild size="sm" variant="ghost">
+          <Link href="/admin/reports">Otvoriť ↗</Link>
+        </Button>
+      </div>
+
+      <div className="mt-3 grid grid-cols-3 gap-3 text-sm">
+        <div>
+          <p className="text-muted-foreground text-xs">Tržby</p>
+          <p className="font-semibold tabular-nums">
+            {formatEur(summary.revenueCents)}
+          </p>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs">Náklady</p>
+          <p className="font-semibold tabular-nums">
+            {formatEur(summary.costCents)}
+          </p>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs">Marža</p>
+          <p
+            className={`font-semibold tabular-nums ${marginColor(summary.marginPct)}`}
+          >
+            {formatPct(summary.marginPct)}
+          </p>
+        </div>
+      </div>
+
+      {summary.untrackedShare > 0.05 && (
+        <p className="mt-2 text-muted-foreground text-xs">
+          Náklady chýbajú pre {Math.round(summary.untrackedShare * 100)} %
+          objednávok (staršie než Phase C).
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/features/reports/components/kpi-card.tsx
+++ b/src/features/reports/components/kpi-card.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@/lib/utils";
+
+interface Props {
+  className?: string;
+  /** Optional delta vs previous period (signed percent). */
+  deltaPct?: number | null;
+  hint?: string;
+  label: string;
+  value: string;
+}
+
+/**
+ * Compact KPI block. One per metric, three or four side-by-side at the
+ * top of a report.
+ */
+export function KpiCard({ label, value, deltaPct, hint, className }: Props) {
+  return (
+    <div className={cn("rounded-lg border bg-card p-4", className)}>
+      <p className="text-muted-foreground text-xs">{label}</p>
+      <p className="mt-1 font-semibold text-2xl tabular-nums">{value}</p>
+      {deltaPct !== undefined && deltaPct !== null && (
+        <p
+          className={cn(
+            "mt-1 text-xs",
+            deltaPct >= 0
+              ? "text-emerald-600 dark:text-emerald-400"
+              : "text-destructive"
+          )}
+        >
+          {deltaPct >= 0 ? "▲" : "▼"}{" "}
+          {Math.abs(deltaPct).toFixed(1).replace(".", ",")} %
+          {" vs predchádzajúce obdobie"}
+        </p>
+      )}
+      {hint && <p className="mt-1 text-muted-foreground text-xs">{hint}</p>}
+    </div>
+  );
+}

--- a/src/features/reports/components/period-picker.tsx
+++ b/src/features/reports/components/period-picker.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const PRESETS = [
+  { value: "7d", label: "Posledných 7 dní" },
+  { value: "30d", label: "Posledných 30 dní" },
+  { value: "90d", label: "Posledných 90 dní" },
+  { value: "mtd", label: "Tento mesiac" },
+  { value: "ytd", label: "Tento rok" },
+] as const;
+
+interface Props {
+  basePath: string;
+}
+
+export function PeriodPicker({ basePath }: Props) {
+  const router = useRouter();
+  const params = useSearchParams();
+  const current = params.get("period") ?? "30d";
+
+  const handleChange = (preset: string) => {
+    const next = new URLSearchParams(params.toString());
+    next.set("period", preset);
+    router.replace(`${basePath}?${next.toString()}` as never);
+  };
+
+  return (
+    <Select onValueChange={handleChange} value={current}>
+      <SelectTrigger className="w-48">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {PRESETS.map((p) => (
+          <SelectItem key={p.value} value={p.value}>
+            {p.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/features/reports/lib/constants.ts
+++ b/src/features/reports/lib/constants.ts
@@ -1,0 +1,31 @@
+import type { OrderStatus } from "@/db/types";
+
+/**
+ * Order statuses that count as a sale in profitability reports.
+ * Cancelled and refunded orders are excluded. See arc overview §12.4.
+ */
+export const PROFIT_ORDER_STATUSES: readonly OrderStatus[] = [
+  "new",
+  "in_progress",
+  "ready_for_pickup",
+  "completed",
+] as const;
+
+/** Margin % bucket boundaries used by the distribution histogram. */
+export const MARGIN_BUCKETS = [
+  { label: "Strata", min: Number.NEGATIVE_INFINITY, max: 0 },
+  { label: "0-10 %", min: 0, max: 10 },
+  { label: "10-30 %", min: 10, max: 30 },
+  { label: "30-50 %", min: 30, max: 50 },
+  { label: "50 %+", min: 50, max: Number.POSITIVE_INFINITY },
+] as const;
+
+export const PERIOD_PRESETS = [
+  "7d",
+  "30d",
+  "90d",
+  "mtd",
+  "ytd",
+  "custom",
+] as const;
+export type PeriodPreset = (typeof PERIOD_PRESETS)[number];

--- a/src/features/reports/lib/format.ts
+++ b/src/features/reports/lib/format.ts
@@ -1,0 +1,34 @@
+/** Slovak EUR formatting for cents. */
+export function formatEur(cents: number | null): string {
+  if (cents === null) {
+    return "—";
+  }
+  return new Intl.NumberFormat("sk-SK", {
+    style: "currency",
+    currency: "EUR",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(cents / 100);
+}
+
+/** Margin %, one decimal place, Slovak format. */
+export function formatPct(value: number | null): string {
+  if (value === null || Number.isNaN(value)) {
+    return "—";
+  }
+  return `${value.toFixed(1).replace(".", ",")} %`;
+}
+
+/** Color class based on margin %. */
+export function marginColor(pct: number | null): string {
+  if (pct === null) {
+    return "text-muted-foreground";
+  }
+  if (pct < 10) {
+    return "text-destructive";
+  }
+  if (pct < 30) {
+    return "text-amber-600 dark:text-amber-400";
+  }
+  return "text-emerald-600 dark:text-emerald-400";
+}

--- a/src/features/reports/lib/period.ts
+++ b/src/features/reports/lib/period.ts
@@ -1,0 +1,59 @@
+import { endOfDay, formatISO, startOfDay, subDays } from "date-fns";
+import type { PeriodPreset } from "./constants";
+
+export interface Period {
+  from: Date;
+  /** Identical-length window immediately before [from, to] for period-over-period. */
+  previousFrom: Date;
+  previousTo: Date;
+  to: Date;
+}
+
+/**
+ * Resolve a preset or custom [from, to] into a fully-populated Period
+ * with a previous comparison window of the same length.
+ */
+export function resolvePeriod(
+  preset: PeriodPreset | undefined,
+  customFromIso?: string,
+  customToIso?: string
+): Period {
+  const now = new Date();
+  const today = endOfDay(now);
+
+  let from: Date;
+  let to: Date = today;
+
+  switch (preset) {
+    case "7d":
+      from = startOfDay(subDays(today, 7));
+      break;
+    case "90d":
+      from = startOfDay(subDays(today, 90));
+      break;
+    case "mtd":
+      from = startOfDay(new Date(today.getFullYear(), today.getMonth(), 1));
+      break;
+    case "ytd":
+      from = startOfDay(new Date(today.getFullYear(), 0, 1));
+      break;
+    case "custom":
+      from = customFromIso
+        ? startOfDay(new Date(customFromIso))
+        : startOfDay(subDays(today, 30));
+      to = customToIso ? endOfDay(new Date(customToIso)) : today;
+      break;
+    default:
+      from = startOfDay(subDays(today, 30));
+  }
+
+  const lengthMs = to.getTime() - from.getTime();
+  const previousTo = new Date(from.getTime() - 1);
+  const previousFrom = new Date(previousTo.getTime() - lengthMs);
+
+  return { from, to, previousFrom, previousTo };
+}
+
+export function formatPeriodForFilename(p: Period): string {
+  return `${formatISO(p.from, { representation: "date" })}_${formatISO(p.to, { representation: "date" })}`;
+}

--- a/src/lib/auth/guards.ts
+++ b/src/lib/auth/guards.ts
@@ -7,18 +7,27 @@ function isStaffRole(role: string): role is (typeof STAFF_ROLES)[number] {
   return (STAFF_ROLES as readonly string[]).includes(role);
 }
 
-export async function requireAdmin() {
+/**
+ * Resource-scoped guard: enforce that the user holds one of the listed roles.
+ * Foundation for the per-resource guards below; lets us tweak who sees what
+ * without grep-and-replacing across feature code.
+ */
+async function requireRoles(allowed: readonly string[]) {
   const user = await getUser();
 
   if (!user) {
     unauthorized();
   }
 
-  if (user.role !== "admin") {
+  if (!allowed.includes(user.role)) {
     forbidden();
   }
 
   return user;
+}
+
+export function requireAdmin() {
+  return requireRoles(["admin"]);
 }
 
 export async function requireAuth() {
@@ -44,6 +53,19 @@ export async function requireStaff() {
 
   return user;
 }
+
+// --- Resource-scoped guards (recipe-costing arc, pre-A scaffolding) ---
+//
+// These wrap `requireRoles` with a per-resource semantic name so when the
+// `baker` role lands in ERP Phase 4, we only edit the `requireRecipeView`
+// allow-list — no churn across feature modules.
+
+export const requireProductEdit = () => requireRoles(STAFF_ROLES);
+export const requireRecipeView = () => requireRoles(STAFF_ROLES); // baker added in Phase 4
+export const requireRecipeEdit = () => requireRoles(STAFF_ROLES);
+export const requireCostView = () => requireRoles(STAFF_ROLES);
+export const requireIngredientEdit = () => requireRoles(STAFF_ROLES);
+export const requireReportsView = () => requireRoles(STAFF_ROLES);
 
 /**
  * Require user to be a member of a B2B organization.

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -29,6 +29,12 @@ const MODULES = [
   "db",
   "payments",
   "invoices",
+  // Recipe-costing arc namespaces (pre-A scaffolding; used by Phases B-E)
+  "ingredients",
+  "recipes",
+  "nutrition",
+  "reports",
+  "products",
 ] as const;
 
 export type LogModule = (typeof MODULES)[number];

--- a/src/widgets/admin-sidebar/app-sidebar.tsx
+++ b/src/widgets/admin-sidebar/app-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import type { LucideIcon } from "lucide-react";
 import {
+  BookOpenIcon,
   BriefcaseIcon,
   FileTextIcon,
   FlaskConicalIcon,
@@ -56,6 +57,11 @@ const NAV_ESHOP: NavItem[] = [
     href: "/admin/ingredients" as Route,
     label: "Suroviny",
     icon: WheatIcon,
+  },
+  {
+    href: "/admin/recipes" as Route,
+    label: "Recepty",
+    icon: BookOpenIcon,
   },
 ];
 

--- a/src/widgets/admin-sidebar/app-sidebar.tsx
+++ b/src/widgets/admin-sidebar/app-sidebar.tsx
@@ -16,6 +16,7 @@ import {
   TagsIcon,
   UsersIcon,
   WalletIcon,
+  WheatIcon,
 } from "lucide-react";
 import type { Route } from "next";
 import Link from "next/link";
@@ -51,6 +52,11 @@ const NAV_ESHOP: NavItem[] = [
   { href: "/admin/stores", label: "Predajne", icon: StoreIcon },
   { href: "/admin/categories", label: "Kategórie", icon: TagsIcon },
   { href: "/admin/products", label: "Produkty", icon: Package2Icon },
+  {
+    href: "/admin/ingredients" as Route,
+    label: "Suroviny",
+    icon: WheatIcon,
+  },
 ];
 
 const NAV_BLOG: NavItem[] = [

--- a/src/widgets/admin-sidebar/app-sidebar.tsx
+++ b/src/widgets/admin-sidebar/app-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import type { LucideIcon } from "lucide-react";
 import {
+  BarChart3Icon,
   BookOpenIcon,
   BriefcaseIcon,
   FileTextIcon,
@@ -62,6 +63,11 @@ const NAV_ESHOP: NavItem[] = [
     href: "/admin/recipes" as Route,
     label: "Recepty",
     icon: BookOpenIcon,
+  },
+  {
+    href: "/admin/reports" as Route,
+    label: "Reporty",
+    icon: BarChart3Icon,
   },
 ];
 


### PR DESCRIPTION
## Summary

End-to-end recipe-costing system spanning allergens, ingredients, recipes, nutrition, and ERP profitability reports. Five phases (A-E) plus pre-A scaffolding, shipped as one branch.

- **Customer-visible:** allergen chips on PDP, EU-format nutrition table on PDP
- **Admin-visible:** ingredients catalog with AI autofill, recipe builder with live cost preview, allergen drift report, store/product P&L reports + CSV export, dashboard profitability widget
- **Behind the scenes:** pure-function cost resolver shared between live preview, server actions, and order snapshot; `order_items.unitCostCents` captured at checkout so future orders carry their cost-at-time-of-sale

Specs in `docs/specs/` describe the full arc (`_arc-overview.md` is the cross-cutting one). Each phase commit has a detailed body.

## What's in each phase

### Pre-A scaffolding (`d311112`)
- `order_items.unitCostCents` nullable column (Phase C populates; landed early so orders between A and C aren't permanently cost-blind)
- Resource-scoped guards: `requireProductEdit`, `requireRecipeView/Edit`, `requireCostView`, `requireIngredientEdit`, `requireReportsView`
- `ingredients`, `recipes`, `nutrition`, `reports`, `products` module loggers

### Phase A — Allergens (`985d553`)
- `allergens` reference table seeded with EU 14 (Reg. 1169/2011) Slovak names
- `products.allergenCodes text[]` + admin chip picker + PDP chip strip
- Phase D switches the source to derived; this column stays as fallback

### Phase B — Ingredients (`1747a6f`)
- `ingredients` table with XOR pricing (`pricePerKgCents` OR `pricePerPieceCents`, CHECK-enforced) — lossless for every realistic supplier price
- `ingredient_price_history` (append-only)
- pg_trgm + unaccent + IMMUTABLE `f_unaccent` wrapper, trigram GIN index
- ~50 seeded bakery staples
- AI nutrition autofill (Claude Sonnet 4.5) with admin-confirm dialog
- Duplicate-suggestion at create time; `/admin/ingredients/duplicates` review tool
- Unit-aware `<PriceInput>` (kg / 500g / 100g / 1 ks / 6/10/12 ks)

### Phase C — Recipes + cost resolver (`0f61e2c`)
- `recipes` + `recipe_items` schema; `products.recipeId` FK
- Pure-function cost resolver in `src/features/recipes/lib/cost-resolver.ts` with cycle/depth/missing-ref guards
- `pnpm test:resolver` — **17/17 passing**
- `/admin/recipes` list + `/admin/recipes/[id]` builder (header form + items table + cmdk picker + sticky live preview)
- Product page Recept card (link/unlink + cost-per-unit summary)
- Order snapshot in `create-b2c-order.ts` — resolver failures log warn + store null, never break checkout

### Phase D — Nutrition + PDP (`052c359`)
- Resolver extended with `batchNutrition` + `nutritionPer100` in the same recursive pass
- `products.nutritionOverride` jsonb column for manual overrides
- `getDerivedProductDisplay` consolidates allergens (derived > manual fallback) + nutrition (override > computed > none)
- EU-format `<NutritionTable>` on PDP (kJ/kcal, salt 2dp, others 1dp, Slovak decimal comma)
- `/admin/recipes/drift` paginated report of products where manual and derived allergens disagree

### Phase E — ERP profitability (`dcb423b`)
- Reports queries: summary, store P&L, product P&L
- Pages: `/admin/reports` landing + `/admin/reports/profitability/{stores,products}`
- CSV export via `/api/admin/reports/export` — UTF-8 BOM + semicolon for Slovak Excel
- Dashboard widget on `/admin` (last-30-day revenue/cost/margin)
- Sidebar: Suroviny, Recepty, Reporty entries

## Migrations applied to dev

```
0007_nasty_leader.sql               — order_items.unitCostCents
0008_certain_ezekiel_stane.sql      — allergens + products.allergenCodes
0009_curved_firebrand.sql           — ingredients + price history + pg_trgm
0010_smart_franklin_storm.sql       — recipes + recipe_items + products.recipeId
0011_rare_spectrum.sql              — products.nutritionOverride
```

All applied to dev. **Not applied to prod** — `pnpm db:migrate:prod` was deliberately not run.

## Verification

- ✅ `pnpm typecheck` — green
- ✅ `pnpm lint` — green (613 files, ultracite + biome)
- ✅ `pnpm test:resolver` — 17/17 passing
- ✅ `pnpm build` — green production build

## Test plan

- [ ] Apply migrations 0007-0011 to staging
- [ ] Verify pg_trgm + unaccent extensions exist (Phase B migration creates them)
- [ ] Add an ingredient via `/admin/ingredients`, test the `<PriceInput>` unit conversion preview
- [ ] Try the AI nutrition autofill (requires `ANTHROPIC_API_KEY`); confirm dialog renders the suggestion side-by-side
- [ ] Type "muka" in the picker — should match "Hladká múka T650" (diacritic-free fuzzy)
- [ ] Create a sub-recipe + a product recipe; attempt to add the product recipe as a sub-recipe of itself — picker should hide it
- [ ] Place a test B2C order; verify `order_items.unitCostCents` is populated when the product has a published recipe
- [ ] Visit PDP for a product with a recipe — verify allergen chips and nutrition table render
- [ ] Visit `/admin/recipes/drift` with a known allergen mismatch — should list the product
- [ ] `/admin/reports/profitability/stores` — verify period picker and CSV export work
- [ ] Dashboard widget on `/admin` shows last-30-day summary

## Known deferred items (noted in commit bodies)

- dnd-kit drag reorder on recipe items (using up/down arrows for now)
- "Z iného receptu" picker dual-mode (use Duplikovať for now)
- Inline ingredient create from picker (link-out instead)
- Autosave items in builder (explicit save via header form, per-row autosave on blur for quantity)
- Admin override toggle UI for `products.nutritionOverride` (column + action flow through; DB-edit works)
- JSON-LD nutritionInformation on PDP
- Ingredient price trends + impact reports (read-only follow-up)
- Per-staff store-level row filtering on reports (waits for Phase 4 store-staff assignments)
- Materialized daily snapshots table (opt-in once a report drags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)